### PR TITLE
Add private Obsidian, ChatGPT and Claude knowledge integrations

### DIFF
--- a/android/CyanBridge/app/src/main/AndroidManifest.xml
+++ b/android/CyanBridge/app/src/main/AndroidManifest.xml
@@ -43,6 +43,7 @@
         <package android:name="com.google.android.googlequicksearchbox" />
         <package android:name="com.google.android.apps.bard" />
         <package android:name="com.openai.chatgpt" />
+        <package android:name="com.anthropic.claude" />
     </queries>
 
     <application
@@ -86,6 +87,7 @@
         <service android:name=".devices.meizumyvu.MeizuMyvuConnectionService" android:exported="false" android:foregroundServiceType="connectedDevice" />
         <activity android:name=".ui.ChatListActivity" android:exported="false" android:label="Chats" />
         <activity android:name=".ui.ChatThreadActivity" android:exported="false" android:label="Chat" android:windowSoftInputMode="adjustResize" />
+        <activity android:name=".integrations.knowledge.KnowledgeIntegrationsActivity" android:exported="false" android:label="Notes &amp; AI imports" />
         <activity android:name=".ui.SettingsActivity" android:exported="false" android:label="Settings" />
         <activity android:name=".ai.image.ExternalAssistantAutomationSetupActivity" android:exported="false" android:label="Gemini / ChatGPT automation setup" />
         <activity android:name=".ui.appearance.AppearanceActivity" android:exported="false" android:label="Appearance" />

--- a/android/CyanBridge/app/src/main/java/com/fersaiyan/cyanbridge/data/local/dao/MemoryChunkDao.kt
+++ b/android/CyanBridge/app/src/main/java/com/fersaiyan/cyanbridge/data/local/dao/MemoryChunkDao.kt
@@ -31,6 +31,9 @@ interface MemoryChunkDao {
     @Query("DELETE FROM memory_chunks WHERE source = :source")
     suspend fun deleteBySource(source: String): Int
 
+    @Query("DELETE FROM memory_chunks WHERE source = :source AND packageName = :packageName")
+    suspend fun deleteBySourceAndPackageName(source: String, packageName: String): Int
+
     @Query("DELETE FROM memory_chunks WHERE source = :source AND tsMs < :beforeTs")
     suspend fun deleteSourceOlderThan(source: String, beforeTs: Long): Int
 

--- a/android/CyanBridge/app/src/main/java/com/fersaiyan/cyanbridge/integrations/knowledge/ExternalAiExportParser.kt
+++ b/android/CyanBridge/app/src/main/java/com/fersaiyan/cyanbridge/integrations/knowledge/ExternalAiExportParser.kt
@@ -1,0 +1,220 @@
+package com.fersaiyan.cyanbridge.integrations.knowledge
+
+import org.json.JSONArray
+import org.json.JSONObject
+import java.nio.charset.StandardCharsets
+
+/** Tolerant parser for account exports. No provider login/session tokens are used. */
+object ExternalAiExportParser {
+
+    data class Parsed(
+        val source: KnowledgeSource,
+        val documents: List<KnowledgeDocument>,
+        val warnings: List<String> = emptyList(),
+    )
+
+    fun parseJson(bytes: ByteArray, filenameHint: String? = null): Parsed {
+        val text = bytes.toString(StandardCharsets.UTF_8).trim()
+        require(text.isNotBlank()) { "The selected export is empty." }
+        val root: Any = when (text.first()) {
+            '[' -> JSONArray(text)
+            '{' -> JSONObject(text)
+            else -> error("Expected a JSON export.")
+        }
+        val source = detectSource(root, filenameHint)
+        return when (source) {
+            KnowledgeSource.CHATGPT -> parseChatGpt(root)
+            KnowledgeSource.CLAUDE -> parseClaude(root)
+            else -> Parsed(source, parseGenericJson(root, source))
+        }
+    }
+
+    private fun detectSource(root: Any, filenameHint: String?): KnowledgeSource {
+        val hint = filenameHint.orEmpty().lowercase()
+        if ("claude" in hint) return KnowledgeSource.CLAUDE
+        if ("chatgpt" in hint || "conversation" in hint) {
+            if (looksLikeChatGpt(root)) return KnowledgeSource.CHATGPT
+        }
+        if (looksLikeChatGpt(root)) return KnowledgeSource.CHATGPT
+        if (looksLikeClaude(root)) return KnowledgeSource.CLAUDE
+        return KnowledgeSource.IMPORT_INBOX
+    }
+
+    private fun looksLikeChatGpt(root: Any): Boolean {
+        val first = firstObject(root) ?: return false
+        return first.has("mapping") || first.has("conversation_id") && first.has("current_node")
+    }
+
+    private fun looksLikeClaude(root: Any): Boolean {
+        val first = firstObject(root) ?: return false
+        return first.has("chat_messages") || first.has("uuid") && (first.has("name") || first.has("summary"))
+    }
+
+    private fun firstObject(root: Any): JSONObject? = when (root) {
+        is JSONArray -> (0 until root.length()).asSequence().mapNotNull { root.optJSONObject(it) }.firstOrNull()
+        is JSONObject -> root.optJSONArray("conversations")?.optJSONObject(0) ?: root
+        else -> null
+    }
+
+    private data class Turn(val role: String, val text: String, val tsMs: Long)
+
+    private fun parseChatGpt(root: Any): Parsed {
+        val conversations = arrayFromRoot(root, "conversations")
+        val docs = mutableListOf<KnowledgeDocument>()
+        val warnings = mutableListOf<String>()
+        for (i in 0 until conversations.length()) {
+            val conversation = conversations.optJSONObject(i) ?: continue
+            val id = conversation.optString("id").ifBlank {
+                conversation.optString("conversation_id").ifBlank { "chatgpt-$i" }
+            }
+            val title = conversation.optString("title").ifBlank { "ChatGPT conversation ${i + 1}" }
+            val mapping = conversation.optJSONObject("mapping")
+            if (mapping == null) {
+                warnings += "$title had no mapping and was skipped."
+                continue
+            }
+            val turns = mutableListOf<Turn>()
+            val keys = mapping.keys()
+            while (keys.hasNext()) {
+                val node = mapping.optJSONObject(keys.next()) ?: continue
+                val message = node.optJSONObject("message") ?: continue
+                val author = message.optJSONObject("author")?.optString("role").orEmpty()
+                if (author !in setOf("user", "assistant", "system", "tool")) continue
+                val content = chatGptContentText(message.optJSONObject("content"))
+                if (content.isBlank()) continue
+                val seconds = message.optDouble("create_time", 0.0)
+                turns += Turn(author, content, if (seconds > 0) (seconds * 1000.0).toLong() else 0L)
+            }
+            val sorted = turns.sortedWith(compareBy<Turn> { if (it.tsMs == 0L) Long.MAX_VALUE else it.tsMs })
+            if (sorted.isEmpty()) continue
+            val updatedAt = sorted.maxOfOrNull { it.tsMs }?.takeIf { it > 0 }
+                ?: ((conversation.optDouble("update_time", 0.0) * 1000.0).toLong()).takeIf { it > 0 }
+                ?: System.currentTimeMillis()
+            docs += KnowledgeDocument(
+                source = KnowledgeSource.CHATGPT,
+                sourceId = id,
+                title = title,
+                text = turnsToMarkdown(title, "ChatGPT", sorted),
+                updatedAtMs = updatedAt,
+                userAuthoredText = sorted.filter { it.role == "user" }.joinToString("\n\n") { it.text },
+            )
+        }
+        return Parsed(KnowledgeSource.CHATGPT, docs, warnings)
+    }
+
+    private fun chatGptContentText(content: JSONObject?): String {
+        if (content == null) return ""
+        val parts = content.optJSONArray("parts") ?: return content.optString("text")
+        return (0 until parts.length()).mapNotNull { index ->
+            when (val value = parts.opt(index)) {
+                is String -> value
+                is JSONObject -> value.optString("text").takeIf { it.isNotBlank() }
+                else -> null
+            }
+        }.joinToString("\n").trim()
+    }
+
+    private fun parseClaude(root: Any): Parsed {
+        val conversations = arrayFromRoot(root, "conversations")
+        val docs = mutableListOf<KnowledgeDocument>()
+        val warnings = mutableListOf<String>()
+        for (i in 0 until conversations.length()) {
+            val conversation = conversations.optJSONObject(i) ?: continue
+            val id = conversation.optString("uuid").ifBlank {
+                conversation.optString("id").ifBlank { "claude-$i" }
+            }
+            val title = conversation.optString("name").ifBlank {
+                conversation.optString("title").ifBlank { "Claude conversation ${i + 1}" }
+            }
+            val messages = conversation.optJSONArray("chat_messages")
+                ?: conversation.optJSONArray("messages")
+                ?: JSONArray()
+            val turns = mutableListOf<Turn>()
+            for (j in 0 until messages.length()) {
+                val message = messages.optJSONObject(j) ?: continue
+                val rawRole = message.optString("sender").ifBlank { message.optString("role") }.lowercase()
+                val role = when (rawRole) {
+                    "human", "user" -> "user"
+                    "assistant", "claude" -> "assistant"
+                    else -> rawRole.ifBlank { "assistant" }
+                }
+                val body = claudeMessageText(message)
+                if (body.isBlank()) continue
+                turns += Turn(role, body, parseClaudeTimestamp(message))
+            }
+            if (turns.isEmpty()) {
+                warnings += "$title had no readable chat messages and was skipped."
+                continue
+            }
+            val updatedAt = turns.maxOfOrNull { it.tsMs }?.takeIf { it > 0 } ?: System.currentTimeMillis()
+            docs += KnowledgeDocument(
+                source = KnowledgeSource.CLAUDE,
+                sourceId = id,
+                title = title,
+                text = turnsToMarkdown(title, "Claude", turns),
+                updatedAtMs = updatedAt,
+                userAuthoredText = turns.filter { it.role == "user" }.joinToString("\n\n") { it.text },
+            )
+        }
+        return Parsed(KnowledgeSource.CLAUDE, docs, warnings)
+    }
+
+    private fun claudeMessageText(message: JSONObject): String {
+        val text = message.optString("text")
+        if (text.isNotBlank()) return text.trim()
+        val content = message.opt("content")
+        return when (content) {
+            is String -> content.trim()
+            is JSONArray -> (0 until content.length()).mapNotNull { i ->
+                when (val part = content.opt(i)) {
+                    is String -> part
+                    is JSONObject -> part.optString("text").takeIf { it.isNotBlank() }
+                    else -> null
+                }
+            }.joinToString("\n").trim()
+            else -> ""
+        }
+    }
+
+    private fun parseClaudeTimestamp(message: JSONObject): Long {
+        val numeric = message.optLong("created_at", 0L)
+        if (numeric > 10_000_000_000L) return numeric
+        if (numeric > 0L) return numeric * 1000L
+        // ISO timestamps are left unordered rather than adding a java.time API requirement here.
+        return 0L
+    }
+
+    private fun parseGenericJson(root: Any, source: KnowledgeSource): List<KnowledgeDocument> {
+        val text = when (root) {
+            is JSONArray -> root.toString(2)
+            is JSONObject -> root.toString(2)
+            else -> root.toString()
+        }
+        return listOf(
+            KnowledgeDocument(
+                source = source,
+                sourceId = "generic-${text.hashCode()}",
+                title = "Imported JSON",
+                text = text,
+                updatedAtMs = System.currentTimeMillis(),
+            )
+        )
+    }
+
+    private fun arrayFromRoot(root: Any, objectKey: String): JSONArray = when (root) {
+        is JSONArray -> root
+        is JSONObject -> root.optJSONArray(objectKey) ?: JSONArray().put(root)
+        else -> JSONArray()
+    }
+
+    private fun turnsToMarkdown(title: String, provider: String, turns: List<Turn>): String = buildString {
+        appendLine("# $title")
+        appendLine()
+        appendLine("_Imported from $provider. Assistant statements are context, not confirmed user facts._")
+        turns.forEach { turn ->
+            appendLine()
+            appendLine(if (turn.role == "user") "## User" else "## Assistant")
+            appendLine(turn.text.trim())
+        }
+    }.trim()
+}

--- a/android/CyanBridge/app/src/main/java/com/fersaiyan/cyanbridge/integrations/knowledge/ImportedKnowledgeIndex.kt
+++ b/android/CyanBridge/app/src/main/java/com/fersaiyan/cyanbridge/integrations/knowledge/ImportedKnowledgeIndex.kt
@@ -1,0 +1,132 @@
+package com.fersaiyan.cyanbridge.integrations.knowledge
+
+import android.content.Context
+import com.fersaiyan.cyanbridge.ai.router.AiProviderPrefs
+import com.fersaiyan.cyanbridge.ai.router.AiProviderType
+import com.fersaiyan.cyanbridge.data.local.entity.MemoryChunk
+import com.fersaiyan.cyanbridge.localagent.memory.LocalAgentMemoryRoomIndex
+import com.fersaiyan.cyanbridge.memoryvault.MemoryModeManager
+import com.fersaiyan.cyanbridge.memoryvault.MemoryPolicyService
+import com.fersaiyan.cyanbridge.memoryvault.MemoryRefMapper
+import com.fersaiyan.cyanbridge.memoryvault.MemoryVaultBootstrap
+import com.fersaiyan.cyanbridge.memoryvault.VaultLockStateManager
+import com.fersaiyan.cyanbridge.ui.MyApplication
+
+/** Local searchable index for inbound external knowledge. */
+object ImportedKnowledgeIndex {
+    const val SOURCE = "imported_text"
+    private const val MAX_CHUNK_CHARS = 2400
+    private const val CHUNK_OVERLAP = 240
+
+    suspend fun replaceSource(
+        context: Context,
+        source: KnowledgeSource,
+        documents: List<KnowledgeDocument>,
+    ): Int {
+        MemoryVaultBootstrap.ensureInitialized(context)
+        val dao = MyApplication.database.memoryChunkDao()
+        dao.deleteBySourceAndPackageName(SOURCE, source.wire)
+
+        var indexed = 0
+        val now = System.currentTimeMillis()
+        documents.forEach { document ->
+            chunk(document.text).forEachIndexed { chunkIndex, payload ->
+                val rowId = dao.insert(
+                    MemoryChunk(
+                        source = SOURCE,
+                        sourceId = "${document.sourceId}#$chunkIndex",
+                        packageName = source.wire,
+                        tsMs = document.updatedAtMs,
+                        text = payload,
+                        createdAt = now,
+                        updatedAt = now,
+                    )
+                )
+                val chunkRef = MemoryRefMapper.forMemoryChunk(rowId)
+                val policy = MemoryPolicyService.classifyForMemoryRef(
+                    context = context,
+                    memoryRef = "import:${source.wire}:${document.sourceId}:$chunkIndex",
+                    text = payload,
+                    sourceTimestampMs = document.updatedAtMs,
+                    provenance = "knowledge_import:${source.wire}",
+                ).copy(memoryRef = chunkRef)
+                MemoryPolicyService.upsertPolicy(policy)
+                indexed++
+            }
+        }
+        return indexed
+    }
+
+    /**
+     * Imported personal material is injected only into on-device model prompts.
+     * Selecting a relay/cloud provider never forwards this corpus automatically.
+     */
+    fun mayInjectIntoCurrentPrompt(context: Context): Boolean =
+        AiProviderPrefs.getProvider(context) == AiProviderType.LOCAL_MODELS &&
+            !VaultLockStateManager.isLocked(context)
+
+    suspend fun relevantBlock(
+        context: Context,
+        query: String,
+        limit: Int = 6,
+        maxChars: Int = 1800,
+    ): String {
+        if (!mayInjectIntoCurrentPrompt(context)) return ""
+        val fts = LocalAgentMemoryRoomIndex.toFtsQuery(query)
+        if (fts.isBlank()) return ""
+        val mode = MemoryModeManager.getSelectedMode(context)
+        val hits = MyApplication.database.memoryChunkDao().searchWithSnippet(fts, (limit * 3).coerceAtLeast(limit))
+            .asSequence()
+            .filter { it.source == SOURCE }
+            .filter { hit ->
+                val ref = MemoryRefMapper.forMemoryChunk(hit.id)
+                val policy = MemoryPolicyService.getPolicyBlocking(ref)
+                    ?: MemoryPolicyService.classifyForMemoryRef(
+                        context = context,
+                        memoryRef = "import:${hit.packageName.orEmpty()}:${hit.sourceId.orEmpty()}",
+                        text = hit.text,
+                        sourceTimestampMs = hit.tsMs,
+                        provenance = "knowledge_import_fallback",
+                    ).copy(memoryRef = ref)
+                MemoryPolicyService.isEligibleForRetrieval(mode, policy)
+            }
+            .take(limit)
+            .toList()
+        if (hits.isEmpty()) return ""
+
+        val block = buildString {
+            appendLine("## Imported personal knowledge")
+            appendLine("Use as private reference. Treat assistant-authored imported text as context, not a confirmed user fact.")
+            hits.forEach { hit ->
+                val provider = KnowledgeSource.fromWire(hit.packageName).label
+                val snippet = hit.snippet.replace("[", "").replace("]", "").ifBlank { hit.text }
+                    .replace('\n', ' ')
+                    .trim()
+                    .take(320)
+                appendLine("- [$provider] $snippet")
+            }
+        }.trim()
+        return if (block.length <= maxChars) block else block.take(maxChars).trimEnd() + "…"
+    }
+
+    internal fun chunk(text: String): List<String> {
+        val clean = text.trim()
+        if (clean.isBlank()) return emptyList()
+        if (clean.length <= MAX_CHUNK_CHARS) return listOf(clean)
+        val out = mutableListOf<String>()
+        var start = 0
+        while (start < clean.length) {
+            var end = (start + MAX_CHUNK_CHARS).coerceAtMost(clean.length)
+            if (end < clean.length) {
+                val paragraph = clean.lastIndexOf("\n\n", end).takeIf { it > start + MAX_CHUNK_CHARS / 2 }
+                val sentence = clean.lastIndexOf(". ", end).takeIf { it > start + MAX_CHUNK_CHARS / 2 }
+                end = paragraph ?: sentence?.plus(1) ?: end
+            }
+            val piece = clean.substring(start, end).trim()
+            if (piece.isNotBlank()) out += piece
+            if (end >= clean.length) break
+            start = (end - CHUNK_OVERLAP).coerceAtLeast(start + 1)
+        }
+        return out
+    }
+}

--- a/android/CyanBridge/app/src/main/java/com/fersaiyan/cyanbridge/integrations/knowledge/KnowledgeImportCoordinator.kt
+++ b/android/CyanBridge/app/src/main/java/com/fersaiyan/cyanbridge/integrations/knowledge/KnowledgeImportCoordinator.kt
@@ -1,0 +1,174 @@
+package com.fersaiyan.cyanbridge.integrations.knowledge
+
+import android.content.Context
+import android.net.Uri
+import android.provider.OpenableColumns
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.io.ByteArrayInputStream
+import java.util.zip.ZipInputStream
+
+object KnowledgeImportCoordinator {
+
+    suspend fun importSelectedFile(
+        context: Context,
+        uri: Uri,
+        expectedSource: KnowledgeSource? = null,
+    ): List<KnowledgeImportResult> = withContext(Dispatchers.IO) {
+        val name = displayName(context, uri) ?: uri.lastPathSegment.orEmpty()
+        val bytes = SafKnowledgeRepository.readBytes(context, uri)
+        val parsed = parseFile(bytes, name, expectedSource)
+        indexParsed(context, parsed)
+    }
+
+    suspend fun syncObsidian(context: Context): KnowledgeImportResult? = withContext(Dispatchers.IO) {
+        val tree = KnowledgeIntegrationPrefs.obsidianTree(context) ?: return@withContext null
+        val docs = SafKnowledgeRepository.scanObsidian(context, tree)
+        val count = ImportedKnowledgeIndex.replaceSource(context, KnowledgeSource.OBSIDIAN, docs)
+        KnowledgeImportResult(KnowledgeSource.OBSIDIAN, docs.size, count)
+    }
+
+    suspend fun syncImportInbox(context: Context): List<KnowledgeImportResult> = withContext(Dispatchers.IO) {
+        val tree = KnowledgeIntegrationPrefs.importInboxTree(context) ?: return@withContext emptyList()
+        val grouped = linkedMapOf<KnowledgeSource, MutableList<KnowledgeDocument>>()
+        val warnings = linkedMapOf<KnowledgeSource, MutableList<String>>()
+
+        SafKnowledgeRepository.scanImportInbox(context, tree).forEach { entry ->
+            runCatching {
+                val bytes = SafKnowledgeRepository.readBytes(context, entry.uri)
+                parseFile(bytes, entry.name, null)
+            }.onSuccess { parsedItems ->
+                parsedItems.forEach { parsed ->
+                    grouped.getOrPut(parsed.source) { mutableListOf() }.addAll(parsed.documents)
+                    warnings.getOrPut(parsed.source) { mutableListOf() }.addAll(parsed.warnings)
+                }
+            }.onFailure { error ->
+                warnings.getOrPut(KnowledgeSource.IMPORT_INBOX) { mutableListOf() }
+                    .add("${entry.name}: ${error.message ?: "could not import"}")
+            }
+        }
+
+        grouped.map { (source, docs) ->
+            val deduped = docs.distinctBy { "${it.sourceId}:${it.text.hashCode()}" }
+            val chunks = ImportedKnowledgeIndex.replaceSource(context, source, deduped)
+            KnowledgeImportResult(source, deduped.size, chunks, warnings[source].orEmpty())
+        } + warnings
+            .filterKeys { it !in grouped.keys }
+            .map { (source, sourceWarnings) -> KnowledgeImportResult(source, 0, 0, sourceWarnings) }
+    }
+
+    suspend fun syncAll(context: Context): List<KnowledgeImportResult> = withContext(Dispatchers.IO) {
+        val results = mutableListOf<KnowledgeImportResult>()
+        syncObsidian(context)?.let(results::add)
+        results += syncImportInbox(context)
+        val summary = results.joinToString(" · ") { it.summary() }.ifBlank { "Nothing connected yet" }
+        KnowledgeIntegrationPrefs.recordSync(context, summary)
+        results
+    }
+
+    private suspend fun indexParsed(
+        context: Context,
+        parsed: List<ExternalAiExportParser.Parsed>,
+    ): List<KnowledgeImportResult> {
+        val grouped = parsed.groupBy { it.source }
+        val out = mutableListOf<KnowledgeImportResult>()
+        grouped.forEach { (source, entries) ->
+            val docs = entries.flatMap { it.documents }.distinctBy { "${it.sourceId}:${it.text.hashCode()}" }
+            val chunks = ImportedKnowledgeIndex.replaceSource(context, source, docs)
+            out += KnowledgeImportResult(
+                source = source,
+                documentsImported = docs.size,
+                chunksIndexed = chunks,
+                warnings = entries.flatMap { it.warnings },
+            )
+        }
+        KnowledgeIntegrationPrefs.recordSync(context, out.joinToString(" · ") { it.summary() })
+        return out
+    }
+
+    private fun parseFile(
+        bytes: ByteArray,
+        filename: String,
+        expectedSource: KnowledgeSource?,
+    ): List<ExternalAiExportParser.Parsed> {
+        val lower = filename.lowercase()
+        if (lower.endsWith(".zip")) return parseZip(bytes, expectedSource)
+        if (lower.endsWith(".md") || lower.endsWith(".txt")) {
+            val source = expectedSource ?: KnowledgeSource.IMPORT_INBOX
+            val text = bytes.toString(Charsets.UTF_8)
+            return listOf(
+                ExternalAiExportParser.Parsed(
+                    source = source,
+                    documents = listOf(
+                        KnowledgeDocument(
+                            source = source,
+                            sourceId = filename,
+                            title = filename.substringBeforeLast('.'),
+                            text = text,
+                            updatedAtMs = System.currentTimeMillis(),
+                            userAuthoredText = if (source == KnowledgeSource.OBSIDIAN) text else "",
+                        )
+                    )
+                )
+            )
+        }
+        val parsed = ExternalAiExportParser.parseJson(bytes, sourceHintFilename(filename, expectedSource))
+        return listOf(parsed)
+    }
+
+    private fun parseZip(bytes: ByteArray, expectedSource: KnowledgeSource?): List<ExternalAiExportParser.Parsed> {
+        val parsed = mutableListOf<ExternalAiExportParser.Parsed>()
+        ZipInputStream(ByteArrayInputStream(bytes)).use { zip ->
+            var entry = zip.nextEntry
+            while (entry != null) {
+                if (!entry.isDirectory && entry.name.lowercase().endsWith(".json")) {
+                    val simple = entry.name.substringAfterLast('/')
+                    val likelyConversationFile = simple.contains("conversation", true) ||
+                        simple.contains("chat", true) || simple.contains("claude", true)
+                    if (likelyConversationFile) {
+                        val entryBytes = zip.readBytesLimited(40_000_000)
+                        runCatching {
+                            ExternalAiExportParser.parseJson(entryBytes, sourceHintFilename(simple, expectedSource))
+                        }.getOrNull()?.let(parsed::add)
+                    }
+                }
+                zip.closeEntry()
+                entry = zip.nextEntry
+            }
+        }
+        require(parsed.isNotEmpty()) {
+            "No recognizable ChatGPT/Claude conversation JSON was found in this ZIP."
+        }
+        return parsed
+    }
+
+    private fun ZipInputStream.readBytesLimited(maxBytes: Int): ByteArray {
+        val out = java.io.ByteArrayOutputStream()
+        val buffer = ByteArray(16 * 1024)
+        var total = 0
+        while (true) {
+            val read = read(buffer)
+            if (read <= 0) break
+            total += read
+            require(total <= maxBytes) { "Conversation JSON is too large for a single import entry." }
+            out.write(buffer, 0, read)
+        }
+        return out.toByteArray()
+    }
+
+    private fun sourceHintFilename(filename: String, expectedSource: KnowledgeSource?): String {
+        return when (expectedSource) {
+            KnowledgeSource.CHATGPT -> "chatgpt-$filename"
+            KnowledgeSource.CLAUDE -> "claude-$filename"
+            else -> filename
+        }
+    }
+
+    private fun displayName(context: Context, uri: Uri): String? {
+        return runCatching {
+            context.contentResolver.query(uri, arrayOf(OpenableColumns.DISPLAY_NAME), null, null, null)?.use { cursor ->
+                if (!cursor.moveToFirst()) null else cursor.getString(0)
+            }
+        }.getOrNull()
+    }
+}

--- a/android/CyanBridge/app/src/main/java/com/fersaiyan/cyanbridge/integrations/knowledge/KnowledgeImportCoordinator.kt
+++ b/android/CyanBridge/app/src/main/java/com/fersaiyan/cyanbridge/integrations/knowledge/KnowledgeImportCoordinator.kt
@@ -22,8 +22,12 @@ object KnowledgeImportCoordinator {
     }
 
     suspend fun syncObsidian(context: Context): KnowledgeImportResult? = withContext(Dispatchers.IO) {
-        val tree = KnowledgeIntegrationPrefs.obsidianTree(context) ?: return@withContext null
-        val docs = SafKnowledgeRepository.scanObsidian(context, tree)
+        val vault = KnowledgeIntegrationPrefs.obsidianVault(context) ?: return@withContext null
+        val docs = SafKnowledgeRepository.scanObsidian(
+            context = context,
+            treeUri = vault.permissionTreeUri,
+            rootDocumentId = vault.rootDocumentId,
+        )
         val count = ImportedKnowledgeIndex.replaceSource(context, KnowledgeSource.OBSIDIAN, docs)
         KnowledgeImportResult(KnowledgeSource.OBSIDIAN, docs.size, count)
     }

--- a/android/CyanBridge/app/src/main/java/com/fersaiyan/cyanbridge/integrations/knowledge/KnowledgeIntegrationPrefs.kt
+++ b/android/CyanBridge/app/src/main/java/com/fersaiyan/cyanbridge/integrations/knowledge/KnowledgeIntegrationPrefs.kt
@@ -1,0 +1,46 @@
+package com.fersaiyan.cyanbridge.integrations.knowledge
+
+import android.content.Context
+import android.net.Uri
+
+object KnowledgeIntegrationPrefs {
+    private const val PREFS = "knowledge_integrations"
+    private const val KEY_OBSIDIAN_TREE = "obsidian_tree_uri"
+    private const val KEY_IMPORT_INBOX_TREE = "import_inbox_tree_uri"
+    private const val KEY_AUTO_SYNC = "auto_sync"
+    private const val KEY_LAST_SYNC = "last_sync_ms"
+    private const val KEY_LAST_SUMMARY = "last_summary"
+
+    private fun prefs(context: Context) = context.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+
+    fun obsidianTree(context: Context): Uri? =
+        prefs(context).getString(KEY_OBSIDIAN_TREE, null)?.takeIf { it.isNotBlank() }?.let(Uri::parse)
+
+    fun setObsidianTree(context: Context, uri: Uri?) {
+        prefs(context).edit().putString(KEY_OBSIDIAN_TREE, uri?.toString()).apply()
+    }
+
+    fun importInboxTree(context: Context): Uri? =
+        prefs(context).getString(KEY_IMPORT_INBOX_TREE, null)?.takeIf { it.isNotBlank() }?.let(Uri::parse)
+
+    fun setImportInboxTree(context: Context, uri: Uri?) {
+        prefs(context).edit().putString(KEY_IMPORT_INBOX_TREE, uri?.toString()).apply()
+    }
+
+    fun autoSyncEnabled(context: Context): Boolean = prefs(context).getBoolean(KEY_AUTO_SYNC, true)
+
+    fun setAutoSyncEnabled(context: Context, enabled: Boolean) {
+        prefs(context).edit().putBoolean(KEY_AUTO_SYNC, enabled).apply()
+    }
+
+    fun lastSyncMs(context: Context): Long = prefs(context).getLong(KEY_LAST_SYNC, 0L)
+
+    fun lastSummary(context: Context): String = prefs(context).getString(KEY_LAST_SUMMARY, "") ?: ""
+
+    fun recordSync(context: Context, summary: String, nowMs: Long = System.currentTimeMillis()) {
+        prefs(context).edit()
+            .putLong(KEY_LAST_SYNC, nowMs)
+            .putString(KEY_LAST_SUMMARY, summary.take(500))
+            .apply()
+    }
+}

--- a/android/CyanBridge/app/src/main/java/com/fersaiyan/cyanbridge/integrations/knowledge/KnowledgeIntegrationPrefs.kt
+++ b/android/CyanBridge/app/src/main/java/com/fersaiyan/cyanbridge/integrations/knowledge/KnowledgeIntegrationPrefs.kt
@@ -6,18 +6,59 @@ import android.net.Uri
 object KnowledgeIntegrationPrefs {
     private const val PREFS = "knowledge_integrations"
     private const val KEY_OBSIDIAN_TREE = "obsidian_tree_uri"
+    private const val KEY_OBSIDIAN_ROOT_DOCUMENT_ID = "obsidian_root_document_id"
+    private const val KEY_OBSIDIAN_DISPLAY_NAME = "obsidian_display_name"
     private const val KEY_IMPORT_INBOX_TREE = "import_inbox_tree_uri"
     private const val KEY_AUTO_SYNC = "auto_sync"
     private const val KEY_LAST_SYNC = "last_sync_ms"
     private const val KEY_LAST_SUMMARY = "last_summary"
+
+    data class ObsidianVaultAccess(
+        val permissionTreeUri: Uri,
+        val rootDocumentId: String?,
+        val displayName: String?,
+    )
 
     private fun prefs(context: Context) = context.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
 
     fun obsidianTree(context: Context): Uri? =
         prefs(context).getString(KEY_OBSIDIAN_TREE, null)?.takeIf { it.isNotBlank() }?.let(Uri::parse)
 
+    fun obsidianRootDocumentId(context: Context): String? =
+        prefs(context).getString(KEY_OBSIDIAN_ROOT_DOCUMENT_ID, null)?.takeIf { it.isNotBlank() }
+
+    fun obsidianDisplayName(context: Context): String? =
+        prefs(context).getString(KEY_OBSIDIAN_DISPLAY_NAME, null)?.takeIf { it.isNotBlank() }
+
+    fun obsidianVault(context: Context): ObsidianVaultAccess? {
+        val tree = obsidianTree(context) ?: return null
+        return ObsidianVaultAccess(
+            permissionTreeUri = tree,
+            rootDocumentId = obsidianRootDocumentId(context),
+            displayName = obsidianDisplayName(context),
+        )
+    }
+
+    /** Existing vault: the selected tree itself is the vault root. */
     fun setObsidianTree(context: Context, uri: Uri?) {
-        prefs(context).edit().putString(KEY_OBSIDIAN_TREE, uri?.toString()).apply()
+        setObsidianVault(context, uri, rootDocumentId = null, displayName = null)
+    }
+
+    /**
+     * Store the scoped tree permission plus an optional logical root document id. The latter is
+     * used when CyanBridge creates a new vault folder under a user-selected parent directory.
+     */
+    fun setObsidianVault(
+        context: Context,
+        permissionTreeUri: Uri?,
+        rootDocumentId: String?,
+        displayName: String?,
+    ) {
+        prefs(context).edit()
+            .putString(KEY_OBSIDIAN_TREE, permissionTreeUri?.toString())
+            .putString(KEY_OBSIDIAN_ROOT_DOCUMENT_ID, rootDocumentId)
+            .putString(KEY_OBSIDIAN_DISPLAY_NAME, displayName)
+            .apply()
     }
 
     fun importInboxTree(context: Context): Uri? =

--- a/android/CyanBridge/app/src/main/java/com/fersaiyan/cyanbridge/integrations/knowledge/KnowledgeIntegrationsActivity.kt
+++ b/android/CyanBridge/app/src/main/java/com/fersaiyan/cyanbridge/integrations/knowledge/KnowledgeIntegrationsActivity.kt
@@ -7,6 +7,7 @@ import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.compose.setContent
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AppCompatActivity
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -29,12 +30,14 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.lifecycleScope
 import com.fersaiyan.cyanbridge.ui.appearance.AppearancePreferences
@@ -50,9 +53,16 @@ import java.util.Locale
 class KnowledgeIntegrationsActivity : AppCompatActivity() {
     private var status by mutableStateOf("Ready")
     private var busy by mutableStateOf(false)
-    private var noteTitle by mutableStateOf("")
-    private var noteBody by mutableStateOf("")
     private var refreshKey by mutableStateOf(0)
+
+    private var newVaultName by mutableStateOf("CyanBridge Vault")
+    private var managedNotes by mutableStateOf<List<SafKnowledgeRepository.SafEntry>>(emptyList())
+    private var editingNoteUri by mutableStateOf<Uri?>(null)
+    private var editingNoteName by mutableStateOf<String?>(null)
+    private var noteCreatedAt by mutableStateOf<String?>(null)
+    private var noteTitle by mutableStateOf("")
+    private var noteTags by mutableStateOf("")
+    private var noteBody by mutableStateOf(TextFieldValue(""))
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -69,12 +79,31 @@ class KnowledgeIntegrationsActivity : AppCompatActivity() {
     @OptIn(ExperimentalMaterial3Api::class)
     @Composable
     private fun KnowledgeIntegrationsScreen() {
-        // refreshKey makes persisted URI/status reads update after picker callbacks.
         @Suppress("UNUSED_VARIABLE") val refresh = refreshKey
-        val obsidianTree = KnowledgeIntegrationPrefs.obsidianTree(this)
+        val obsidianVault = KnowledgeIntegrationPrefs.obsidianVault(this)
+        val obsidianWritable = obsidianVault?.let {
+            SafKnowledgeRepository.hasPersistedTreePermission(this, it.permissionTreeUri, writable = true)
+        } == true
         val inboxTree = KnowledgeIntegrationPrefs.importInboxTree(this)
+        val inboxReadable = inboxTree?.let {
+            SafKnowledgeRepository.hasPersistedTreePermission(this, it, writable = false)
+        } == true
         val autoSync = KnowledgeIntegrationPrefs.autoSyncEnabled(this)
         val lastSummary = KnowledgeIntegrationPrefs.lastSummary(this)
+
+        LaunchedEffect(refreshKey, obsidianVault?.permissionTreeUri, obsidianVault?.rootDocumentId, obsidianWritable) {
+            managedNotes = if (obsidianVault != null && obsidianWritable) {
+                withContext(Dispatchers.IO) {
+                    SafKnowledgeRepository.listManagedObsidianNotes(
+                        context = this@KnowledgeIntegrationsActivity,
+                        treeUri = obsidianVault.permissionTreeUri,
+                        rootDocumentId = obsidianVault.rootDocumentId,
+                    )
+                }
+            } else {
+                emptyList()
+            }
+        }
 
         val chatGptImport = rememberLauncherForActivityResult(ActivityResultContracts.OpenDocument()) { uri ->
             uri?.let { importFile(it, KnowledgeSource.CHATGPT) }
@@ -82,21 +111,23 @@ class KnowledgeIntegrationsActivity : AppCompatActivity() {
         val claudeImport = rememberLauncherForActivityResult(ActivityResultContracts.OpenDocument()) { uri ->
             uri?.let { importFile(it, KnowledgeSource.CLAUDE) }
         }
-        val obsidianPicker = rememberLauncherForActivityResult(ActivityResultContracts.OpenDocumentTree()) { uri ->
-            uri?.let { selected ->
-                SafKnowledgeRepository.persistTreePermission(this, selected, writable = true)
-                KnowledgeIntegrationPrefs.setObsidianTree(this, selected)
-                refreshKey++
-                syncAllNow()
-            }
+        val existingVaultPicker = rememberLauncherForActivityResult(ActivityResultContracts.OpenDocumentTree()) { uri ->
+            uri?.let(::connectExistingVault)
+        }
+        val createVaultParentPicker = rememberLauncherForActivityResult(ActivityResultContracts.OpenDocumentTree()) { uri ->
+            uri?.let(::createVaultUnderParent)
         }
         val inboxPicker = rememberLauncherForActivityResult(ActivityResultContracts.OpenDocumentTree()) { uri ->
             uri?.let { selected ->
-                SafKnowledgeRepository.persistTreePermission(this, selected, writable = false)
-                KnowledgeIntegrationPrefs.setImportInboxTree(this, selected)
-                refreshKey++
-                KnowledgeSyncWorker.schedule(this)
-                syncAllNow()
+                if (SafKnowledgeRepository.persistTreePermission(this, selected, writable = false)) {
+                    KnowledgeIntegrationPrefs.setImportInboxTree(this, selected)
+                    status = "Import folder connected with read-only scoped access."
+                    refreshKey++
+                    KnowledgeSyncWorker.schedule(this)
+                    syncAllNow()
+                } else {
+                    status = "Could not retain read access to that import folder. Choose it again and grant access."
+                }
             }
         }
 
@@ -134,27 +165,29 @@ class KnowledgeIntegrationsActivity : AppCompatActivity() {
                     enabled = !busy,
                 ) { claudeImport.launch(arrayOf("application/zip", "application/json", "text/json", "application/octet-stream")) }
 
-                ConnectionCard(
-                    title = "Obsidian vault",
-                    connected = obsidianTree != null,
-                    body = if (obsidianTree == null) {
-                        "Grant CyanBridge access to one vault folder. Markdown notes are indexed for local RAG, and CyanBridge can write notes back into a CyanBridge/ folder inside the vault."
-                    } else {
-                        "Vault connected. Changes can be re-indexed periodically without broad storage permission."
-                    },
-                    connectLabel = if (obsidianTree == null) "Choose vault" else "Change vault",
-                    onConnect = { obsidianPicker.launch(obsidianTree) },
+                ObsidianVaultCard(
+                    vault = obsidianVault,
+                    hasWritablePermission = obsidianWritable,
+                    onChooseExisting = { existingVaultPicker.launch(obsidianVault?.permissionTreeUri) },
+                    onCreateNew = { createVaultParentPicker.launch(null) },
                 )
 
-                if (obsidianTree != null) {
-                    ObsidianNoteEditor(onSave = { saveObsidianNote(obsidianTree) })
+                if (obsidianVault != null && obsidianWritable) {
+                    ObsidianNoteEditor(
+                        onSave = { saveObsidianNote(obsidianVault) },
+                        onNew = ::resetNoteEditor,
+                    )
                 }
 
                 ConnectionCard(
                     title = "Automatic import inbox",
-                    connected = inboxTree != null,
-                    body = "Optional bridge folder for .zip, .json, .md, or .txt files. A desktop/browser companion, Syncthing, FolderSync, or another user-controlled tool can drop new snapshots here; CyanBridge periodically re-indexes the folder without provider credentials.",
-                    connectLabel = if (inboxTree == null) "Choose import folder" else "Change import folder",
+                    connected = inboxTree != null && inboxReadable,
+                    body = if (inboxTree != null && !inboxReadable) {
+                        "The stored folder permission is no longer available. Reconnect the folder to resume automatic imports."
+                    } else {
+                        "Optional bridge folder for .zip, .json, .md, or .txt files. A desktop/browser companion, Syncthing, FolderSync, or another user-controlled tool can drop new snapshots here; CyanBridge periodically re-indexes it without provider credentials."
+                    },
+                    connectLabel = if (inboxTree == null) "Choose import folder" else "Reconnect import folder",
                     onConnect = { inboxPicker.launch(inboxTree) },
                 )
 
@@ -170,7 +203,7 @@ class KnowledgeIntegrationsActivity : AppCompatActivity() {
                         ) {
                             Column(modifier = Modifier.weight(1f)) {
                                 Text("Periodic local sync", fontWeight = FontWeight.SemiBold)
-                                Text("Every 12 hours when enabled; no network is required.", style = MaterialTheme.typography.bodySmall)
+                                Text("Every 12 hours when enabled; no provider login is required.", style = MaterialTheme.typography.bodySmall)
                             }
                             Switch(
                                 checked = autoSync,
@@ -183,7 +216,7 @@ class KnowledgeIntegrationsActivity : AppCompatActivity() {
                         }
                         Button(
                             onClick = ::syncAllNow,
-                            enabled = !busy && (obsidianTree != null || inboxTree != null),
+                            enabled = !busy && ((obsidianVault != null && obsidianWritable) || (inboxTree != null && inboxReadable)),
                             modifier = Modifier.fillMaxWidth(),
                         ) { Text(if (busy) "Working…" else "Sync now") }
                     }
@@ -209,9 +242,86 @@ class KnowledgeIntegrationsActivity : AppCompatActivity() {
             Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
                 Text("Inbound-only private knowledge", fontWeight = FontWeight.Bold)
                 Text(
-                    "These integrations pull data into CyanBridge; they do not upload CyanBridge chats, notes, memories, or vault content to ChatGPT or Claude. Imported knowledge is automatically added to AI prompt context only when the on-device Local Models provider is selected.",
+                    "These integrations pull data into CyanBridge; they do not upload CyanBridge chats, memories, imported notes, or vault content to ChatGPT or Claude. Imported knowledge is automatically added to AI prompt context only when the on-device Local Models provider is selected.",
                     style = MaterialTheme.typography.bodyMedium,
                 )
+            }
+        }
+    }
+
+    @Composable
+    private fun ObsidianVaultCard(
+        vault: KnowledgeIntegrationPrefs.ObsidianVaultAccess?,
+        hasWritablePermission: Boolean,
+        onChooseExisting: () -> Unit,
+        onCreateNew: () -> Unit,
+    ) {
+        Card(modifier = Modifier.fillMaxWidth()) {
+            Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(10.dp)) {
+                Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
+                    Text("Obsidian / Markdown vault", fontWeight = FontWeight.SemiBold)
+                    Text(
+                        when {
+                            vault == null -> "Not connected"
+                            hasWritablePermission -> "Read + write"
+                            else -> "Permission needed"
+                        },
+                        style = MaterialTheme.typography.labelMedium,
+                    )
+                }
+                if (vault?.displayName != null) {
+                    Text("Vault: ${vault.displayName}", style = MaterialTheme.typography.bodySmall)
+                }
+                Text(
+                    if (vault != null && !hasWritablePermission) {
+                        "CyanBridge no longer has retained read/write access to this location. Reconnect it before notes can be indexed or edited."
+                    } else {
+                        "Choose an existing Obsidian vault, or create a normal Markdown vault if you do not have one yet. Android will ask you to grant CyanBridge access to that folder; no broad storage permission is requested."
+                    },
+                    style = MaterialTheme.typography.bodyMedium,
+                )
+                OutlinedButton(
+                    onClick = onChooseExisting,
+                    enabled = !busy,
+                    modifier = Modifier.fillMaxWidth(),
+                ) { Text(if (vault == null) "Connect existing vault" else "Reconnect / change vault") }
+
+                Text("Create a new vault", fontWeight = FontWeight.Medium)
+                OutlinedTextField(
+                    value = newVaultName,
+                    onValueChange = { newVaultName = it },
+                    label = { Text("Vault folder name") },
+                    supportingText = { Text("You will choose the parent location next.") },
+                    modifier = Modifier.fillMaxWidth(),
+                    singleLine = true,
+                )
+                Button(
+                    onClick = onCreateNew,
+                    enabled = !busy && newVaultName.isNotBlank(),
+                    modifier = Modifier.fillMaxWidth(),
+                ) { Text("Create new Markdown vault") }
+
+                Text(
+                    "Storage note: files in an Obsidian vault are ordinary plaintext .md files so Obsidian and other Markdown apps can read them. CyanBridge Memory Vault encryption does not encrypt these external source files. Protect them with device/storage encryption or an encrypted sync/storage provider if needed.",
+                    style = MaterialTheme.typography.bodySmall,
+                )
+                if (vault != null) {
+                    TextButton(
+                        onClick = {
+                            KnowledgeIntegrationPrefs.setObsidianVault(
+                                this@KnowledgeIntegrationsActivity,
+                                permissionTreeUri = null,
+                                rootDocumentId = null,
+                                displayName = null,
+                            )
+                            resetNoteEditor()
+                            managedNotes = emptyList()
+                            status = "Obsidian vault disconnected. Existing Markdown files were not deleted."
+                            refreshKey++
+                        },
+                        enabled = !busy,
+                    ) { Text("Disconnect vault") }
+                }
             }
         }
     }
@@ -254,11 +364,46 @@ class KnowledgeIntegrationsActivity : AppCompatActivity() {
     }
 
     @Composable
-    private fun ObsidianNoteEditor(onSave: () -> Unit) {
+    private fun ObsidianNoteEditor(
+        onSave: () -> Unit,
+        onNew: () -> Unit,
+    ) {
         Card(modifier = Modifier.fillMaxWidth()) {
             Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(10.dp)) {
-                Text("New Obsidian note", fontWeight = FontWeight.SemiBold)
-                Text("Write or paste a transcription/idea here. It is saved as Markdown and becomes available to local RAG after sync.")
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Column(modifier = Modifier.weight(1f)) {
+                        Text(
+                            if (editingNoteUri == null) "New Markdown note" else "Editing Markdown note",
+                            fontWeight = FontWeight.SemiBold,
+                        )
+                        editingNoteName?.let { Text(it, style = MaterialTheme.typography.bodySmall) }
+                    }
+                    if (editingNoteUri != null || noteBody.text.isNotBlank() || noteTitle.isNotBlank()) {
+                        TextButton(onClick = onNew, enabled = !busy) { Text("New") }
+                    }
+                }
+                Text(
+                    "CyanBridge manages notes in the vault's CyanBridge/ folder. Other vault notes remain searchable but are not overwritten by this editor.",
+                    style = MaterialTheme.typography.bodySmall,
+                )
+
+                if (managedNotes.isNotEmpty()) {
+                    Text("Recent CyanBridge notes", fontWeight = FontWeight.Medium)
+                    managedNotes.take(8).forEach { entry ->
+                        TextButton(
+                            onClick = { loadManagedNote(entry) },
+                            enabled = !busy,
+                            modifier = Modifier.fillMaxWidth(),
+                        ) {
+                            Text("Edit ${entry.name}", modifier = Modifier.fillMaxWidth())
+                        }
+                    }
+                }
+
                 OutlinedTextField(
                     value = noteTitle,
                     onValueChange = { noteTitle = it },
@@ -267,19 +412,110 @@ class KnowledgeIntegrationsActivity : AppCompatActivity() {
                     singleLine = true,
                 )
                 OutlinedTextField(
+                    value = noteTags,
+                    onValueChange = { noteTags = it },
+                    label = { Text("Tags") },
+                    supportingText = { Text("Comma- or space-separated; # is optional. Saved as Obsidian YAML tags.") },
+                    modifier = Modifier.fillMaxWidth(),
+                    singleLine = true,
+                )
+
+                Text("Markdown toolbar", fontWeight = FontWeight.Medium)
+                MarkdownToolbar()
+
+                OutlinedTextField(
                     value = noteBody,
                     onValueChange = { noteBody = it },
                     label = { Text("Markdown note") },
+                    supportingText = { Text("Supports headings, lists, tasks, links, wiki links, tags, quotes, code, bold and italic Markdown.") },
                     modifier = Modifier.fillMaxWidth(),
-                    minLines = 6,
-                    maxLines = 16,
+                    minLines = 10,
+                    maxLines = 24,
                 )
                 Button(
                     onClick = onSave,
-                    enabled = !busy && noteBody.isNotBlank(),
+                    enabled = !busy && noteBody.text.isNotBlank(),
                     modifier = Modifier.fillMaxWidth(),
-                ) { Text("Save to Obsidian") }
+                ) { Text(if (editingNoteUri == null) "Create note in Obsidian" else "Update note in Obsidian") }
             }
+        }
+    }
+
+    @Composable
+    private fun MarkdownToolbar() {
+        Row(
+            modifier = Modifier.fillMaxWidth().horizontalScroll(rememberScrollState()),
+            horizontalArrangement = Arrangement.spacedBy(6.dp),
+        ) {
+            ToolButton("H1") { noteBody = MarkdownEditorActions.prefixCurrentLine(noteBody, "# ") }
+            ToolButton("• List") { noteBody = MarkdownEditorActions.prefixCurrentLine(noteBody, "- ") }
+            ToolButton("☐ Task") { noteBody = MarkdownEditorActions.prefixCurrentLine(noteBody, "- [ ] ") }
+            ToolButton("1. List") { noteBody = MarkdownEditorActions.prefixCurrentLine(noteBody, "1. ") }
+            ToolButton("Bold") { noteBody = MarkdownEditorActions.wrap(noteBody, "**", "**", "bold") }
+            ToolButton("Italic") { noteBody = MarkdownEditorActions.wrap(noteBody, "_", "_", "italic") }
+            ToolButton("Code") { noteBody = MarkdownEditorActions.wrap(noteBody, "`", "`", "code") }
+            ToolButton("Quote") { noteBody = MarkdownEditorActions.prefixCurrentLine(noteBody, "> ") }
+            ToolButton("Link") { noteBody = MarkdownEditorActions.wrap(noteBody, "[", "](https://)", "link text") }
+            ToolButton("#tag") { noteBody = MarkdownEditorActions.insert(noteBody, "#tag") }
+            ToolButton("[[Wiki]]") { noteBody = MarkdownEditorActions.wrap(noteBody, "[[", "]]", "note") }
+        }
+    }
+
+    @Composable
+    private fun ToolButton(label: String, onClick: () -> Unit) {
+        OutlinedButton(onClick = onClick, enabled = !busy) { Text(label) }
+    }
+
+    private fun connectExistingVault(selected: Uri) {
+        if (!SafKnowledgeRepository.persistTreePermission(this, selected, writable = true)) {
+            status = "CyanBridge needs retained read and write access to use an Obsidian vault. Please choose the folder again and allow access."
+            return
+        }
+        KnowledgeIntegrationPrefs.setObsidianVault(
+            context = this,
+            permissionTreeUri = selected,
+            rootDocumentId = null,
+            displayName = selected.lastPathSegment?.substringAfterLast(':')?.takeIf { it.isNotBlank() },
+        )
+        resetNoteEditor()
+        status = "Obsidian vault connected with scoped read/write access."
+        refreshKey++
+        syncAllNow()
+    }
+
+    private fun createVaultUnderParent(parent: Uri) {
+        if (!SafKnowledgeRepository.persistTreePermission(this, parent, writable = true)) {
+            status = "CyanBridge needs read and write access to the selected parent location before it can create a vault."
+            return
+        }
+        lifecycleScope.launch {
+            busy = true
+            status = "Creating Markdown vault…"
+            val result = runCatching {
+                withContext(Dispatchers.IO) {
+                    SafKnowledgeRepository.createObsidianVault(
+                        context = this@KnowledgeIntegrationsActivity,
+                        parentTreeUri = parent,
+                        requestedName = newVaultName,
+                    )
+                }
+            }
+            result.onSuccess { created ->
+                KnowledgeIntegrationPrefs.setObsidianVault(
+                    context = this@KnowledgeIntegrationsActivity,
+                    permissionTreeUri = created.permissionTreeUri,
+                    rootDocumentId = created.rootDocumentId,
+                    displayName = created.displayName,
+                )
+                resetNoteEditor()
+                status = "Created '${created.displayName}'. You can open this folder as a vault in Obsidian, or use it directly from CyanBridge."
+                refreshKey++
+                KnowledgeSyncWorker.schedule(this@KnowledgeIntegrationsActivity)
+            }.onFailure {
+                status = "Could not create vault: ${it.message ?: "unknown error"}"
+            }
+            busy = false
+            if (result.isSuccess) syncAllNow()
         }
     }
 
@@ -316,38 +552,78 @@ class KnowledgeIntegrationsActivity : AppCompatActivity() {
         }
     }
 
-    private fun saveObsidianNote(treeUri: Uri) {
+    private fun loadManagedNote(entry: SafKnowledgeRepository.SafEntry) {
         lifecycleScope.launch {
             busy = true
-            status = "Saving note to Obsidian…"
+            status = "Opening ${entry.name}…"
             val result = runCatching {
                 withContext(Dispatchers.IO) {
-                    val date = SimpleDateFormat("yyyy-MM-dd HH:mm", Locale.US).format(Date())
-                    val title = noteTitle.trim().ifBlank { "CyanBridge note ${date.substringBefore(' ')}" }
-                    val markdown = buildString {
-                        appendLine("---")
-                        appendLine("source: cyanbridge")
-                        appendLine("created: \"$date\"")
-                        appendLine("---")
-                        appendLine()
-                        appendLine("# $title")
-                        appendLine()
-                        appendLine(noteBody.trim())
-                    }
-                    SafKnowledgeRepository.saveObsidianNote(this@KnowledgeIntegrationsActivity, treeUri, title, markdown)
-                    KnowledgeImportCoordinator.syncObsidian(this@KnowledgeIntegrationsActivity)
+                    SafKnowledgeRepository.readManagedObsidianNote(this@KnowledgeIntegrationsActivity, entry)
                 }
-            }
-            status = result.fold(
-                onSuccess = { "Saved to Obsidian and re-indexed locally." },
-                onFailure = { "Could not save note: ${it.message ?: "unknown error"}" },
-            )
-            if (result.isSuccess) {
-                noteTitle = ""
-                noteBody = ""
+            }.map { markdown -> ObsidianMarkdownCodec.parse(entry.name, markdown) }
+            result.onSuccess { draft ->
+                editingNoteUri = entry.uri
+                editingNoteName = entry.name
+                noteCreatedAt = draft.createdAt
+                noteTitle = draft.title
+                noteTags = draft.tags
+                noteBody = TextFieldValue(draft.body)
+                status = "Editing ${entry.name}."
+            }.onFailure {
+                status = "Could not open note: ${it.message ?: "unknown error"}"
             }
             busy = false
-            refreshKey++
+        }
+    }
+
+    private fun resetNoteEditor() {
+        editingNoteUri = null
+        editingNoteName = null
+        noteCreatedAt = null
+        noteTitle = ""
+        noteTags = ""
+        noteBody = TextFieldValue("")
+    }
+
+    private fun saveObsidianNote(vault: KnowledgeIntegrationPrefs.ObsidianVaultAccess) {
+        lifecycleScope.launch {
+            busy = true
+            status = if (editingNoteUri == null) "Creating note in Obsidian…" else "Updating note in Obsidian…"
+            val now = SimpleDateFormat("yyyy-MM-dd HH:mm", Locale.US).format(Date())
+            val title = noteTitle.trim().ifBlank { "CyanBridge note ${now.substringBefore(' ')}" }
+            val draft = ObsidianManagedDraft(
+                title = title,
+                tags = noteTags,
+                body = noteBody.text,
+                createdAt = noteCreatedAt,
+            )
+            val markdown = ObsidianMarkdownCodec.render(draft, now)
+            val result = runCatching {
+                withContext(Dispatchers.IO) {
+                    val saved = SafKnowledgeRepository.saveObsidianNote(
+                        context = this@KnowledgeIntegrationsActivity,
+                        treeUri = vault.permissionTreeUri,
+                        rootDocumentId = vault.rootDocumentId,
+                        title = title,
+                        markdown = markdown,
+                        existingUri = editingNoteUri,
+                    )
+                    KnowledgeImportCoordinator.syncObsidian(this@KnowledgeIntegrationsActivity)
+                    saved
+                }
+            }
+            result.onSuccess { savedUri ->
+                editingNoteUri = savedUri
+                editingNoteName = if (title.endsWith(".md", true)) title else "$title.md"
+                noteCreatedAt = noteCreatedAt ?: now
+                noteTitle = title
+                noteTags = ObsidianMarkdownCodec.normalizeTags(noteTags).joinToString(", ")
+                status = "Saved as plaintext Markdown in the Obsidian vault and re-indexed locally."
+                refreshKey++
+            }.onFailure {
+                status = "Could not save note: ${it.message ?: "unknown error"}"
+            }
+            busy = false
         }
     }
 }

--- a/android/CyanBridge/app/src/main/java/com/fersaiyan/cyanbridge/integrations/knowledge/KnowledgeIntegrationsActivity.kt
+++ b/android/CyanBridge/app/src/main/java/com/fersaiyan/cyanbridge/integrations/knowledge/KnowledgeIntegrationsActivity.kt
@@ -1,0 +1,353 @@
+package com.fersaiyan.cyanbridge.integrations.knowledge
+
+import android.content.Intent
+import android.net.Uri
+import android.os.Bundle
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.compose.setContent
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.appcompat.app.AppCompatActivity
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.lifecycleScope
+import com.fersaiyan.cyanbridge.ui.appearance.AppearancePreferences
+import com.fersaiyan.cyanbridge.ui.appearance.rememberAppearanceSettings
+import com.fersaiyan.cyanbridge.ui.theme.CyanBridgeTheme
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+class KnowledgeIntegrationsActivity : AppCompatActivity() {
+    private var status by mutableStateOf("Ready")
+    private var busy by mutableStateOf(false)
+    private var noteTitle by mutableStateOf("")
+    private var noteBody by mutableStateOf("")
+    private var refreshKey by mutableStateOf(0)
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        KnowledgeSyncWorker.schedule(this)
+        val appearancePreferences = AppearancePreferences(this)
+        setContent {
+            val appearance by rememberAppearanceSettings(appearancePreferences)
+            CyanBridgeTheme(appearance) {
+                KnowledgeIntegrationsScreen()
+            }
+        }
+    }
+
+    @OptIn(ExperimentalMaterial3Api::class)
+    @Composable
+    private fun KnowledgeIntegrationsScreen() {
+        // refreshKey makes persisted URI/status reads update after picker callbacks.
+        @Suppress("UNUSED_VARIABLE") val refresh = refreshKey
+        val obsidianTree = KnowledgeIntegrationPrefs.obsidianTree(this)
+        val inboxTree = KnowledgeIntegrationPrefs.importInboxTree(this)
+        val autoSync = KnowledgeIntegrationPrefs.autoSyncEnabled(this)
+        val lastSummary = KnowledgeIntegrationPrefs.lastSummary(this)
+
+        val chatGptImport = rememberLauncherForActivityResult(ActivityResultContracts.OpenDocument()) { uri ->
+            uri?.let { importFile(it, KnowledgeSource.CHATGPT) }
+        }
+        val claudeImport = rememberLauncherForActivityResult(ActivityResultContracts.OpenDocument()) { uri ->
+            uri?.let { importFile(it, KnowledgeSource.CLAUDE) }
+        }
+        val obsidianPicker = rememberLauncherForActivityResult(ActivityResultContracts.OpenDocumentTree()) { uri ->
+            uri?.let { selected ->
+                SafKnowledgeRepository.persistTreePermission(this, selected, writable = true)
+                KnowledgeIntegrationPrefs.setObsidianTree(this, selected)
+                refreshKey++
+                syncAllNow()
+            }
+        }
+        val inboxPicker = rememberLauncherForActivityResult(ActivityResultContracts.OpenDocumentTree()) { uri ->
+            uri?.let { selected ->
+                SafKnowledgeRepository.persistTreePermission(this, selected, writable = false)
+                KnowledgeIntegrationPrefs.setImportInboxTree(this, selected)
+                refreshKey++
+                KnowledgeSyncWorker.schedule(this)
+                syncAllNow()
+            }
+        }
+
+        Scaffold(
+            topBar = {
+                TopAppBar(
+                    title = { Text("Notes & AI imports") },
+                    navigationIcon = {
+                        TextButton(onClick = { finish() }) { Text("Back") }
+                    },
+                )
+            },
+        ) { innerPadding ->
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(innerPadding)
+                    .verticalScroll(rememberScrollState())
+                    .padding(16.dp),
+                verticalArrangement = Arrangement.spacedBy(14.dp),
+            ) {
+                PrivacyCard()
+
+                ImportCard(
+                    title = "ChatGPT",
+                    body = "Import an official ChatGPT data export (.zip or conversations.json). CyanBridge reads it locally and never logs in to your ChatGPT account.",
+                    button = "Import ChatGPT export",
+                    enabled = !busy,
+                ) { chatGptImport.launch(arrayOf("application/zip", "application/json", "text/json", "application/octet-stream")) }
+
+                ImportCard(
+                    title = "Claude",
+                    body = "Import a Claude data export locally. User turns and assistant turns stay distinct so assistant output is never promoted to a confirmed personal fact.",
+                    button = "Import Claude export",
+                    enabled = !busy,
+                ) { claudeImport.launch(arrayOf("application/zip", "application/json", "text/json", "application/octet-stream")) }
+
+                ConnectionCard(
+                    title = "Obsidian vault",
+                    connected = obsidianTree != null,
+                    body = if (obsidianTree == null) {
+                        "Grant CyanBridge access to one vault folder. Markdown notes are indexed for local RAG, and CyanBridge can write notes back into a CyanBridge/ folder inside the vault."
+                    } else {
+                        "Vault connected. Changes can be re-indexed periodically without broad storage permission."
+                    },
+                    connectLabel = if (obsidianTree == null) "Choose vault" else "Change vault",
+                    onConnect = { obsidianPicker.launch(obsidianTree) },
+                )
+
+                if (obsidianTree != null) {
+                    ObsidianNoteEditor(onSave = { saveObsidianNote(obsidianTree) })
+                }
+
+                ConnectionCard(
+                    title = "Automatic import inbox",
+                    connected = inboxTree != null,
+                    body = "Optional bridge folder for .zip, .json, .md, or .txt files. A desktop/browser companion, Syncthing, FolderSync, or another user-controlled tool can drop new snapshots here; CyanBridge periodically re-indexes the folder without provider credentials.",
+                    connectLabel = if (inboxTree == null) "Choose import folder" else "Change import folder",
+                    onConnect = { inboxPicker.launch(inboxTree) },
+                )
+
+                Card(modifier = Modifier.fillMaxWidth()) {
+                    Column(
+                        modifier = Modifier.padding(16.dp),
+                        verticalArrangement = Arrangement.spacedBy(10.dp),
+                    ) {
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.SpaceBetween,
+                        ) {
+                            Column(modifier = Modifier.weight(1f)) {
+                                Text("Periodic local sync", fontWeight = FontWeight.SemiBold)
+                                Text("Every 12 hours when enabled; no network is required.", style = MaterialTheme.typography.bodySmall)
+                            }
+                            Switch(
+                                checked = autoSync,
+                                onCheckedChange = { enabled ->
+                                    KnowledgeIntegrationPrefs.setAutoSyncEnabled(this@KnowledgeIntegrationsActivity, enabled)
+                                    KnowledgeSyncWorker.schedule(this@KnowledgeIntegrationsActivity)
+                                    refreshKey++
+                                },
+                            )
+                        }
+                        Button(
+                            onClick = ::syncAllNow,
+                            enabled = !busy && (obsidianTree != null || inboxTree != null),
+                            modifier = Modifier.fillMaxWidth(),
+                        ) { Text(if (busy) "Working…" else "Sync now") }
+                    }
+                }
+
+                Card(modifier = Modifier.fillMaxWidth()) {
+                    Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(6.dp)) {
+                        Text("Status", fontWeight = FontWeight.SemiBold)
+                        Text(status)
+                        if (lastSummary.isNotBlank() && lastSummary != status) {
+                            Text("Last sync: $lastSummary", style = MaterialTheme.typography.bodySmall)
+                        }
+                    }
+                }
+                Spacer(Modifier.height(20.dp))
+            }
+        }
+    }
+
+    @Composable
+    private fun PrivacyCard() {
+        Card(modifier = Modifier.fillMaxWidth()) {
+            Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                Text("Inbound-only private knowledge", fontWeight = FontWeight.Bold)
+                Text(
+                    "These integrations pull data into CyanBridge; they do not upload CyanBridge chats, notes, memories, or vault content to ChatGPT or Claude. Imported knowledge is automatically added to AI prompt context only when the on-device Local Models provider is selected.",
+                    style = MaterialTheme.typography.bodyMedium,
+                )
+            }
+        }
+    }
+
+    @Composable
+    private fun ImportCard(
+        title: String,
+        body: String,
+        button: String,
+        enabled: Boolean,
+        onClick: () -> Unit,
+    ) {
+        Card(modifier = Modifier.fillMaxWidth()) {
+            Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(10.dp)) {
+                Text(title, fontWeight = FontWeight.SemiBold)
+                Text(body, style = MaterialTheme.typography.bodyMedium)
+                Button(onClick = onClick, enabled = enabled, modifier = Modifier.fillMaxWidth()) { Text(button) }
+            }
+        }
+    }
+
+    @Composable
+    private fun ConnectionCard(
+        title: String,
+        connected: Boolean,
+        body: String,
+        connectLabel: String,
+        onConnect: () -> Unit,
+    ) {
+        Card(modifier = Modifier.fillMaxWidth()) {
+            Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(10.dp)) {
+                Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
+                    Text(title, fontWeight = FontWeight.SemiBold)
+                    Text(if (connected) "Connected" else "Not connected", style = MaterialTheme.typography.labelMedium)
+                }
+                Text(body, style = MaterialTheme.typography.bodyMedium)
+                OutlinedButton(onClick = onConnect, enabled = !busy, modifier = Modifier.fillMaxWidth()) { Text(connectLabel) }
+            }
+        }
+    }
+
+    @Composable
+    private fun ObsidianNoteEditor(onSave: () -> Unit) {
+        Card(modifier = Modifier.fillMaxWidth()) {
+            Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(10.dp)) {
+                Text("New Obsidian note", fontWeight = FontWeight.SemiBold)
+                Text("Write or paste a transcription/idea here. It is saved as Markdown and becomes available to local RAG after sync.")
+                OutlinedTextField(
+                    value = noteTitle,
+                    onValueChange = { noteTitle = it },
+                    label = { Text("Title") },
+                    modifier = Modifier.fillMaxWidth(),
+                    singleLine = true,
+                )
+                OutlinedTextField(
+                    value = noteBody,
+                    onValueChange = { noteBody = it },
+                    label = { Text("Markdown note") },
+                    modifier = Modifier.fillMaxWidth(),
+                    minLines = 6,
+                    maxLines = 16,
+                )
+                Button(
+                    onClick = onSave,
+                    enabled = !busy && noteBody.isNotBlank(),
+                    modifier = Modifier.fillMaxWidth(),
+                ) { Text("Save to Obsidian") }
+            }
+        }
+    }
+
+    private fun importFile(uri: Uri, source: KnowledgeSource) {
+        runCatching {
+            contentResolver.takePersistableUriPermission(uri, Intent.FLAG_GRANT_READ_URI_PERMISSION)
+        }
+        lifecycleScope.launch {
+            busy = true
+            status = "Importing ${source.label}…"
+            val result = runCatching {
+                KnowledgeImportCoordinator.importSelectedFile(this@KnowledgeIntegrationsActivity, uri, source)
+            }
+            status = result.fold(
+                onSuccess = { items -> items.joinToString(" · ") { it.summary() }.ifBlank { "No conversations found." } },
+                onFailure = { "Import failed: ${it.message ?: "unknown error"}" },
+            )
+            busy = false
+            refreshKey++
+        }
+    }
+
+    private fun syncAllNow() {
+        lifecycleScope.launch {
+            busy = true
+            status = "Syncing local knowledge…"
+            val result = runCatching { KnowledgeImportCoordinator.syncAll(this@KnowledgeIntegrationsActivity) }
+            status = result.fold(
+                onSuccess = { items -> items.joinToString(" · ") { it.summary() }.ifBlank { "Nothing connected yet." } },
+                onFailure = { "Sync failed: ${it.message ?: "unknown error"}" },
+            )
+            busy = false
+            refreshKey++
+        }
+    }
+
+    private fun saveObsidianNote(treeUri: Uri) {
+        lifecycleScope.launch {
+            busy = true
+            status = "Saving note to Obsidian…"
+            val result = runCatching {
+                withContext(Dispatchers.IO) {
+                    val date = SimpleDateFormat("yyyy-MM-dd HH:mm", Locale.US).format(Date())
+                    val title = noteTitle.trim().ifBlank { "CyanBridge note ${date.substringBefore(' ')}" }
+                    val markdown = buildString {
+                        appendLine("---")
+                        appendLine("source: cyanbridge")
+                        appendLine("created: \"$date\"")
+                        appendLine("---")
+                        appendLine()
+                        appendLine("# $title")
+                        appendLine()
+                        appendLine(noteBody.trim())
+                    }
+                    SafKnowledgeRepository.saveObsidianNote(this@KnowledgeIntegrationsActivity, treeUri, title, markdown)
+                    KnowledgeImportCoordinator.syncObsidian(this@KnowledgeIntegrationsActivity)
+                }
+            }
+            status = result.fold(
+                onSuccess = { "Saved to Obsidian and re-indexed locally." },
+                onFailure = { "Could not save note: ${it.message ?: "unknown error"}" },
+            )
+            if (result.isSuccess) {
+                noteTitle = ""
+                noteBody = ""
+            }
+            busy = false
+            refreshKey++
+        }
+    }
+}

--- a/android/CyanBridge/app/src/main/java/com/fersaiyan/cyanbridge/integrations/knowledge/KnowledgeModels.kt
+++ b/android/CyanBridge/app/src/main/java/com/fersaiyan/cyanbridge/integrations/knowledge/KnowledgeModels.kt
@@ -1,0 +1,42 @@
+package com.fersaiyan.cyanbridge.integrations.knowledge
+
+enum class KnowledgeSource(val wire: String, val label: String) {
+    CHATGPT("chatgpt", "ChatGPT"),
+    CLAUDE("claude", "Claude"),
+    OBSIDIAN("obsidian", "Obsidian"),
+    IMPORT_INBOX("import_inbox", "Import inbox"),
+    SHARED_TEXT("shared_text", "Shared text");
+
+    companion object {
+        fun fromWire(value: String?): KnowledgeSource =
+            entries.firstOrNull { it.wire == value } ?: IMPORT_INBOX
+    }
+}
+
+data class KnowledgeDocument(
+    val source: KnowledgeSource,
+    val sourceId: String,
+    val title: String,
+    val text: String,
+    val updatedAtMs: Long,
+    /** User-authored turns only. Never promote assistant output to a user fact. */
+    val userAuthoredText: String = "",
+)
+
+data class KnowledgeImportResult(
+    val source: KnowledgeSource,
+    val documentsImported: Int,
+    val chunksIndexed: Int,
+    val warnings: List<String> = emptyList(),
+) {
+    fun summary(): String = buildString {
+        append(source.label)
+        append(": ")
+        append(documentsImported)
+        append(if (documentsImported == 1) " document" else " documents")
+        append(", ")
+        append(chunksIndexed)
+        append(if (chunksIndexed == 1) " searchable chunk" else " searchable chunks")
+        if (warnings.isNotEmpty()) append(" · ${warnings.size} warning(s)")
+    }
+}

--- a/android/CyanBridge/app/src/main/java/com/fersaiyan/cyanbridge/integrations/knowledge/KnowledgeSyncWorker.kt
+++ b/android/CyanBridge/app/src/main/java/com/fersaiyan/cyanbridge/integrations/knowledge/KnowledgeSyncWorker.kt
@@ -1,0 +1,54 @@
+package com.fersaiyan.cyanbridge.integrations.knowledge
+
+import android.content.Context
+import androidx.work.CoroutineWorker
+import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.ExistingWorkPolicy
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.PeriodicWorkRequestBuilder
+import androidx.work.WorkManager
+import androidx.work.WorkerParameters
+import java.util.concurrent.TimeUnit
+
+class KnowledgeSyncWorker(
+    appContext: Context,
+    params: WorkerParameters,
+) : CoroutineWorker(appContext, params) {
+
+    override suspend fun doWork(): Result {
+        if (!KnowledgeIntegrationPrefs.autoSyncEnabled(applicationContext)) return Result.success()
+        return runCatching {
+            KnowledgeImportCoordinator.syncAll(applicationContext)
+            Result.success()
+        }.getOrElse {
+            if (runAttemptCount < 2) Result.retry() else Result.failure()
+        }
+    }
+
+    companion object {
+        private const val PERIODIC_NAME = "knowledge-integrations-periodic-sync"
+        private const val ONE_TIME_NAME = "knowledge-integrations-sync-now"
+
+        fun schedule(context: Context) {
+            if (!KnowledgeIntegrationPrefs.autoSyncEnabled(context)) {
+                WorkManager.getInstance(context).cancelUniqueWork(PERIODIC_NAME)
+                return
+            }
+            val request = PeriodicWorkRequestBuilder<KnowledgeSyncWorker>(12, TimeUnit.HOURS).build()
+            WorkManager.getInstance(context).enqueueUniquePeriodicWork(
+                PERIODIC_NAME,
+                ExistingPeriodicWorkPolicy.UPDATE,
+                request,
+            )
+        }
+
+        fun syncNow(context: Context) {
+            val request = OneTimeWorkRequestBuilder<KnowledgeSyncWorker>().build()
+            WorkManager.getInstance(context).enqueueUniqueWork(
+                ONE_TIME_NAME,
+                ExistingWorkPolicy.REPLACE,
+                request,
+            )
+        }
+    }
+}

--- a/android/CyanBridge/app/src/main/java/com/fersaiyan/cyanbridge/integrations/knowledge/ObsidianMarkdownEditor.kt
+++ b/android/CyanBridge/app/src/main/java/com/fersaiyan/cyanbridge/integrations/knowledge/ObsidianMarkdownEditor.kt
@@ -1,0 +1,126 @@
+package com.fersaiyan.cyanbridge.integrations.knowledge
+
+import androidx.compose.ui.text.TextRange
+import androidx.compose.ui.text.input.TextFieldValue
+
+/** Editable representation of a Markdown note managed inside the vault's CyanBridge/ folder. */
+data class ObsidianManagedDraft(
+    val title: String,
+    val tags: String,
+    val body: String,
+    val createdAt: String? = null,
+)
+
+object ObsidianMarkdownCodec {
+    fun parse(fileName: String, markdown: String): ObsidianManagedDraft {
+        val normalized = markdown.replace("\r\n", "\n")
+        var content = normalized
+        var createdAt: String? = null
+        var tags = ""
+
+        if (normalized.startsWith("---\n")) {
+            val end = normalized.indexOf("\n---\n", startIndex = 4)
+            if (end >= 0) {
+                val frontMatter = normalized.substring(4, end)
+                frontMatter.lineSequence().forEach { line ->
+                    val key = line.substringBefore(':', "").trim().lowercase()
+                    val value = line.substringAfter(':', "").trim()
+                    when (key) {
+                        "created" -> createdAt = value.trim('"').takeIf { it.isNotBlank() }
+                        "tags" -> tags = parseTags(value)
+                    }
+                }
+                content = normalized.substring(end + "\n---\n".length)
+            }
+        }
+
+        val lines = content.lines().toMutableList()
+        while (lines.firstOrNull()?.isBlank() == true) lines.removeAt(0)
+        val fallbackTitle = fileName.removeSuffix(".md")
+        val title = lines.firstOrNull()?.takeIf { it.startsWith("# ") }?.removePrefix("# ")?.trim()
+            ?.takeIf { it.isNotBlank() }
+            ?: fallbackTitle
+        if (lines.firstOrNull()?.startsWith("# ") == true) lines.removeAt(0)
+        while (lines.firstOrNull()?.isBlank() == true) lines.removeAt(0)
+
+        return ObsidianManagedDraft(
+            title = title,
+            tags = tags,
+            body = lines.joinToString("\n").trimEnd(),
+            createdAt = createdAt,
+        )
+    }
+
+    fun render(draft: ObsidianManagedDraft, now: String): String {
+        val tags = normalizeTags(draft.tags)
+        return buildString {
+            appendLine("---")
+            appendLine("source: cyanbridge")
+            appendLine("created: \"${draft.createdAt ?: now}\"")
+            appendLine("updated: \"$now\"")
+            if (tags.isNotEmpty()) appendLine("tags: [${tags.joinToString(", ")}]")
+            appendLine("---")
+            appendLine()
+            appendLine("# ${draft.title.trim()}")
+            appendLine()
+            append(draft.body.trimEnd())
+            appendLine()
+        }
+    }
+
+    fun normalizeTags(raw: String): List<String> = raw
+        .split(',', ' ', '\n', '\t')
+        .asSequence()
+        .map { it.trim().removePrefix("#") }
+        .filter { it.isNotBlank() }
+        .map { tag -> tag.replace(Regex("[^A-Za-z0-9_/-]"), "-").trim('-') }
+        .filter { it.isNotBlank() }
+        .distinct()
+        .take(30)
+        .toList()
+
+    private fun parseTags(value: String): String {
+        val stripped = value.trim().removePrefix("[").removeSuffix("]")
+        return normalizeTags(stripped).joinToString(", ")
+    }
+}
+
+/** Selection-aware transformations used by the lightweight Markdown toolbar. */
+object MarkdownEditorActions {
+    fun wrap(
+        value: TextFieldValue,
+        prefix: String,
+        suffix: String = prefix,
+        placeholder: String,
+    ): TextFieldValue {
+        val start = minOf(value.selection.start, value.selection.end).coerceIn(0, value.text.length)
+        val end = maxOf(value.selection.start, value.selection.end).coerceIn(start, value.text.length)
+        val selected = value.text.substring(start, end)
+        val replacementText = selected.ifBlank { placeholder }
+        val replacement = prefix + replacementText + suffix
+        val newText = value.text.replaceRange(start, end, replacement)
+        val selection = if (selected.isBlank()) {
+            TextRange(start + prefix.length, start + prefix.length + placeholder.length)
+        } else {
+            TextRange(start + replacement.length)
+        }
+        return TextFieldValue(newText, selection)
+    }
+
+    fun insert(value: TextFieldValue, insertion: String): TextFieldValue {
+        val start = minOf(value.selection.start, value.selection.end).coerceIn(0, value.text.length)
+        val end = maxOf(value.selection.start, value.selection.end).coerceIn(start, value.text.length)
+        val newText = value.text.replaceRange(start, end, insertion)
+        return TextFieldValue(newText, TextRange(start + insertion.length))
+    }
+
+    fun prefixCurrentLine(value: TextFieldValue, prefix: String): TextFieldValue {
+        val cursor = minOf(value.selection.start, value.selection.end).coerceIn(0, value.text.length)
+        val lineStart = value.text.lastIndexOf('\n', (cursor - 1).coerceAtLeast(0))
+            .let { if (it < 0) 0 else it + 1 }
+        val newText = value.text.replaceRange(lineStart, lineStart, prefix)
+        val newStart = (value.selection.start + prefix.length).coerceAtMost(newText.length)
+        val newEnd = (value.selection.end + prefix.length).coerceAtMost(newText.length)
+        return TextFieldValue(newText, TextRange(newStart, newEnd))
+    }
+}

--- a/android/CyanBridge/app/src/main/java/com/fersaiyan/cyanbridge/integrations/knowledge/SafKnowledgeRepository.kt
+++ b/android/CyanBridge/app/src/main/java/com/fersaiyan/cyanbridge/integrations/knowledge/SafKnowledgeRepository.kt
@@ -1,0 +1,196 @@
+package com.fersaiyan.cyanbridge.integrations.knowledge
+
+import android.content.ContentResolver
+import android.content.Context
+import android.net.Uri
+import android.provider.DocumentsContract
+import java.io.ByteArrayOutputStream
+import java.util.ArrayDeque
+
+/**
+ * Storage Access Framework bridge used for Obsidian and a user-selected import inbox.
+ * CyanBridge never requests broad storage access; it can only see the tree the user grants.
+ */
+object SafKnowledgeRepository {
+    private const val MAX_TEXT_BYTES = 1_500_000
+    private const val MAX_FILES_PER_SCAN = 2500
+
+    data class SafEntry(
+        val uri: Uri,
+        val documentId: String,
+        val name: String,
+        val mimeType: String,
+        val lastModified: Long,
+        val size: Long,
+        val relativePath: String,
+        val isDirectory: Boolean,
+    )
+
+    fun persistTreePermission(context: Context, uri: Uri, writable: Boolean) {
+        var flags = android.content.Intent.FLAG_GRANT_READ_URI_PERMISSION
+        if (writable) flags = flags or android.content.Intent.FLAG_GRANT_WRITE_URI_PERMISSION
+        runCatching { context.contentResolver.takePersistableUriPermission(uri, flags) }
+    }
+
+    fun scanObsidian(context: Context, treeUri: Uri): List<KnowledgeDocument> {
+        return listTree(context.contentResolver, treeUri)
+            .asSequence()
+            .filterNot { it.isDirectory }
+            .filter { it.name.endsWith(".md", ignoreCase = true) }
+            .filterNot { it.relativePath.split('/').any { part -> part == ".obsidian" || part.startsWith(".") } }
+            .mapNotNull { entry ->
+                val text = readText(context.contentResolver, entry.uri) ?: return@mapNotNull null
+                KnowledgeDocument(
+                    source = KnowledgeSource.OBSIDIAN,
+                    sourceId = entry.relativePath,
+                    title = entry.name.removeSuffix(".md"),
+                    text = text,
+                    updatedAtMs = entry.lastModified.takeIf { it > 0 } ?: System.currentTimeMillis(),
+                    userAuthoredText = text,
+                )
+            }
+            .toList()
+    }
+
+    fun scanImportInbox(context: Context, treeUri: Uri): List<SafEntry> =
+        listTree(context.contentResolver, treeUri)
+            .filterNot { it.isDirectory }
+            .filter { entry ->
+                val name = entry.name.lowercase()
+                name.endsWith(".json") || name.endsWith(".zip") || name.endsWith(".md") || name.endsWith(".txt")
+            }
+
+    fun readBytes(context: Context, uri: Uri, maxBytes: Int = 30_000_000): ByteArray {
+        val resolver = context.contentResolver
+        resolver.openInputStream(uri)?.use { input ->
+            val out = ByteArrayOutputStream()
+            val buffer = ByteArray(16 * 1024)
+            var total = 0
+            while (true) {
+                val read = input.read(buffer)
+                if (read <= 0) break
+                total += read
+                require(total <= maxBytes) { "Selected file is larger than ${maxBytes / 1_000_000} MB." }
+                out.write(buffer, 0, read)
+            }
+            return out.toByteArray()
+        }
+        error("Unable to open selected file.")
+    }
+
+    fun saveObsidianNote(
+        context: Context,
+        treeUri: Uri,
+        title: String,
+        markdown: String,
+    ): Uri {
+        val rootId = DocumentsContract.getTreeDocumentId(treeUri)
+        val root = DocumentsContract.buildDocumentUriUsingTree(treeUri, rootId)
+        val rootChildren = queryChildren(context.contentResolver, treeUri, rootId, "")
+        val cyanDir = rootChildren.firstOrNull { it.isDirectory && it.name == "CyanBridge" }?.uri
+            ?: DocumentsContract.createDocument(
+                context.contentResolver,
+                root,
+                DocumentsContract.Document.MIME_TYPE_DIR,
+                "CyanBridge",
+            )
+            ?: error("Could not create the CyanBridge folder in the Obsidian vault.")
+
+        val safeTitle = title.trim().ifBlank { "CyanBridge note" }
+            .replace(Regex("[\\/:*?\"<>|]"), "-")
+            .take(100)
+        val fileName = if (safeTitle.endsWith(".md", true)) safeTitle else "$safeTitle.md"
+        val dirId = DocumentsContract.getDocumentId(cyanDir)
+        val existing = queryChildren(context.contentResolver, treeUri, dirId, "CyanBridge")
+            .firstOrNull { !it.isDirectory && it.name == fileName }
+        val target = existing?.uri ?: DocumentsContract.createDocument(
+            context.contentResolver,
+            cyanDir,
+            "text/markdown",
+            fileName,
+        ) ?: error("Could not create the note in the Obsidian vault.")
+
+        context.contentResolver.openOutputStream(target, "wt")?.use { output ->
+            output.write(markdown.toByteArray(Charsets.UTF_8))
+        } ?: error("Could not write the Obsidian note.")
+        return target
+    }
+
+    private fun readText(resolver: ContentResolver, uri: Uri): String? = runCatching {
+        resolver.openInputStream(uri)?.use { input ->
+            val bytes = ByteArrayOutputStream()
+            val buffer = ByteArray(16 * 1024)
+            var total = 0
+            while (true) {
+                val read = input.read(buffer)
+                if (read <= 0) break
+                total += read
+                if (total > MAX_TEXT_BYTES) break
+                bytes.write(buffer, 0, read)
+            }
+            bytes.toString(Charsets.UTF_8.name())
+        }
+    }.getOrNull()
+
+    private fun listTree(resolver: ContentResolver, treeUri: Uri): List<SafEntry> {
+        val rootId = DocumentsContract.getTreeDocumentId(treeUri)
+        val queue = ArrayDeque<Pair<String, String>>()
+        queue.add(rootId to "")
+        val out = mutableListOf<SafEntry>()
+        while (queue.isNotEmpty() && out.size < MAX_FILES_PER_SCAN) {
+            val (parentId, parentPath) = queue.removeFirst()
+            val children = queryChildren(resolver, treeUri, parentId, parentPath)
+            children.forEach { entry ->
+                if (out.size >= MAX_FILES_PER_SCAN) return@forEach
+                out += entry
+                if (entry.isDirectory) queue.add(entry.documentId to entry.relativePath)
+            }
+        }
+        return out
+    }
+
+    private fun queryChildren(
+        resolver: ContentResolver,
+        treeUri: Uri,
+        parentDocumentId: String,
+        parentPath: String,
+    ): List<SafEntry> {
+        val childrenUri = DocumentsContract.buildChildDocumentsUriUsingTree(treeUri, parentDocumentId)
+        val projection = arrayOf(
+            DocumentsContract.Document.COLUMN_DOCUMENT_ID,
+            DocumentsContract.Document.COLUMN_DISPLAY_NAME,
+            DocumentsContract.Document.COLUMN_MIME_TYPE,
+            DocumentsContract.Document.COLUMN_LAST_MODIFIED,
+            DocumentsContract.Document.COLUMN_SIZE,
+        )
+        return runCatching {
+            resolver.query(childrenUri, projection, null, null, null)?.use { cursor ->
+                val idIndex = cursor.getColumnIndexOrThrow(DocumentsContract.Document.COLUMN_DOCUMENT_ID)
+                val nameIndex = cursor.getColumnIndexOrThrow(DocumentsContract.Document.COLUMN_DISPLAY_NAME)
+                val mimeIndex = cursor.getColumnIndexOrThrow(DocumentsContract.Document.COLUMN_MIME_TYPE)
+                val modifiedIndex = cursor.getColumnIndexOrThrow(DocumentsContract.Document.COLUMN_LAST_MODIFIED)
+                val sizeIndex = cursor.getColumnIndexOrThrow(DocumentsContract.Document.COLUMN_SIZE)
+                buildList {
+                    while (cursor.moveToNext()) {
+                        val id = cursor.getString(idIndex)
+                        val name = cursor.getString(nameIndex) ?: continue
+                        val mime = cursor.getString(mimeIndex).orEmpty()
+                        val relative = if (parentPath.isBlank()) name else "$parentPath/$name"
+                        add(
+                            SafEntry(
+                                uri = DocumentsContract.buildDocumentUriUsingTree(treeUri, id),
+                                documentId = id,
+                                name = name,
+                                mimeType = mime,
+                                lastModified = if (cursor.isNull(modifiedIndex)) 0L else cursor.getLong(modifiedIndex),
+                                size = if (cursor.isNull(sizeIndex)) 0L else cursor.getLong(sizeIndex),
+                                relativePath = relative,
+                                isDirectory = mime == DocumentsContract.Document.MIME_TYPE_DIR,
+                            )
+                        )
+                    }
+                }
+            }.orEmpty()
+        }.getOrDefault(emptyList())
+    }
+}

--- a/android/CyanBridge/app/src/main/java/com/fersaiyan/cyanbridge/integrations/knowledge/SafKnowledgeRepository.kt
+++ b/android/CyanBridge/app/src/main/java/com/fersaiyan/cyanbridge/integrations/knowledge/SafKnowledgeRepository.kt
@@ -10,10 +10,16 @@ import java.util.ArrayDeque
 /**
  * Storage Access Framework bridge used for Obsidian and a user-selected import inbox.
  * CyanBridge never requests broad storage access; it can only see the tree the user grants.
+ *
+ * An existing vault uses the granted tree as its root. A vault created by CyanBridge keeps
+ * permission to the user-selected parent tree and stores the created vault's document id as the
+ * logical root. This lets CyanBridge create a normal Obsidian-compatible folder without asking
+ * for all-files access.
  */
 object SafKnowledgeRepository {
     private const val MAX_TEXT_BYTES = 1_500_000
     private const val MAX_FILES_PER_SCAN = 2500
+    private const val MANAGED_NOTES_DIR = "CyanBridge"
 
     data class SafEntry(
         val uri: Uri,
@@ -26,14 +32,67 @@ object SafKnowledgeRepository {
         val isDirectory: Boolean,
     )
 
-    fun persistTreePermission(context: Context, uri: Uri, writable: Boolean) {
+    data class CreatedVault(
+        val permissionTreeUri: Uri,
+        val rootDocumentId: String,
+        val displayName: String,
+    )
+
+    data class PersistedAccess(
+        val canRead: Boolean,
+        val canWrite: Boolean,
+    )
+
+    fun persistTreePermission(context: Context, uri: Uri, writable: Boolean): Boolean {
         var flags = android.content.Intent.FLAG_GRANT_READ_URI_PERMISSION
         if (writable) flags = flags or android.content.Intent.FLAG_GRANT_WRITE_URI_PERMISSION
         runCatching { context.contentResolver.takePersistableUriPermission(uri, flags) }
+        return hasPersistedTreePermission(context, uri, writable)
     }
 
-    fun scanObsidian(context: Context, treeUri: Uri): List<KnowledgeDocument> {
-        return listTree(context.contentResolver, treeUri)
+    fun persistedAccess(context: Context, uri: Uri): PersistedAccess {
+        val permission = context.contentResolver.persistedUriPermissions.firstOrNull { it.uri == uri }
+        return PersistedAccess(
+            canRead = permission?.isReadPermission == true,
+            canWrite = permission?.isWritePermission == true,
+        )
+    }
+
+    fun hasPersistedTreePermission(context: Context, uri: Uri, writable: Boolean): Boolean {
+        val access = persistedAccess(context, uri)
+        return access.canRead && (!writable || access.canWrite)
+    }
+
+    /** Create a plain Markdown Obsidian vault folder under a parent chosen by the user. */
+    fun createObsidianVault(context: Context, parentTreeUri: Uri, requestedName: String): CreatedVault {
+        require(hasPersistedTreePermission(context, parentTreeUri, writable = true)) {
+            "CyanBridge needs read and write access to the selected parent folder to create a vault."
+        }
+        val resolver = context.contentResolver
+        val parentRootId = DocumentsContract.getTreeDocumentId(parentTreeUri)
+        val parentRoot = DocumentsContract.buildDocumentUriUsingTree(parentTreeUri, parentRootId)
+        val safeName = sanitizeDirectoryName(requestedName.ifBlank { "CyanBridge Vault" })
+        val siblings = queryChildren(resolver, parentTreeUri, parentRootId, "")
+        require(siblings.none { it.isDirectory && it.name.equals(safeName, ignoreCase = true) }) {
+            "A folder named '$safeName' already exists there. Choose it as an existing vault or use another name."
+        }
+        val vaultDocument = DocumentsContract.createDocument(
+            resolver,
+            parentRoot,
+            DocumentsContract.Document.MIME_TYPE_DIR,
+            safeName,
+        ) ?: error("Could not create the Obsidian vault folder.")
+        val vaultRootId = DocumentsContract.getDocumentId(vaultDocument)
+        ensureManagedNotesDirectory(resolver, parentTreeUri, vaultRootId)
+        return CreatedVault(parentTreeUri, vaultRootId, safeName)
+    }
+
+    fun scanObsidian(
+        context: Context,
+        treeUri: Uri,
+        rootDocumentId: String? = null,
+    ): List<KnowledgeDocument> {
+        return listTree(context.contentResolver, treeUri, resolveRootId(treeUri, rootDocumentId))
             .asSequence()
             .filterNot { it.isDirectory }
             .filter { it.name.endsWith(".md", ignoreCase = true) }
@@ -52,8 +111,29 @@ object SafKnowledgeRepository {
             .toList()
     }
 
+    fun listManagedObsidianNotes(
+        context: Context,
+        treeUri: Uri,
+        rootDocumentId: String? = null,
+        limit: Int = 30,
+    ): List<SafEntry> {
+        val resolver = context.contentResolver
+        val rootId = resolveRootId(treeUri, rootDocumentId)
+        val managedDir = findManagedNotesDirectory(resolver, treeUri, rootId) ?: return emptyList()
+        return queryChildren(resolver, treeUri, managedDir.documentId, MANAGED_NOTES_DIR)
+            .asSequence()
+            .filterNot { it.isDirectory }
+            .filter { it.name.endsWith(".md", ignoreCase = true) }
+            .sortedByDescending { it.lastModified }
+            .take(limit)
+            .toList()
+    }
+
+    fun readManagedObsidianNote(context: Context, entry: SafEntry): String =
+        readText(context.contentResolver, entry.uri) ?: error("Could not read ${entry.name}.")
+
     fun scanImportInbox(context: Context, treeUri: Uri): List<SafEntry> =
-        listTree(context.contentResolver, treeUri)
+        listTree(context.contentResolver, treeUri, DocumentsContract.getTreeDocumentId(treeUri))
             .filterNot { it.isDirectory }
             .filter { entry ->
                 val name = entry.name.lowercase()
@@ -78,43 +158,85 @@ object SafKnowledgeRepository {
         error("Unable to open selected file.")
     }
 
+    /**
+     * Save a CyanBridge-managed Markdown note. The source .md file intentionally remains plain
+     * Markdown in the external Obsidian vault; CyanBridge Memory Vault encryption does not alter it.
+     */
     fun saveObsidianNote(
         context: Context,
         treeUri: Uri,
         title: String,
         markdown: String,
+        rootDocumentId: String? = null,
+        existingUri: Uri? = null,
     ): Uri {
-        val rootId = DocumentsContract.getTreeDocumentId(treeUri)
-        val root = DocumentsContract.buildDocumentUriUsingTree(treeUri, rootId)
-        val rootChildren = queryChildren(context.contentResolver, treeUri, rootId, "")
-        val cyanDir = rootChildren.firstOrNull { it.isDirectory && it.name == "CyanBridge" }?.uri
-            ?: DocumentsContract.createDocument(
-                context.contentResolver,
-                root,
-                DocumentsContract.Document.MIME_TYPE_DIR,
-                "CyanBridge",
-            )
-            ?: error("Could not create the CyanBridge folder in the Obsidian vault.")
-
-        val safeTitle = title.trim().ifBlank { "CyanBridge note" }
-            .replace(Regex("[\\/:*?\"<>|]"), "-")
-            .take(100)
+        require(hasPersistedTreePermission(context, treeUri, writable = true)) {
+            "Write access to this Obsidian location is no longer available. Reconnect the vault."
+        }
+        val resolver = context.contentResolver
+        val rootId = resolveRootId(treeUri, rootDocumentId)
+        val cyanDir = ensureManagedNotesDirectory(resolver, treeUri, rootId)
+        val safeTitle = sanitizeFileTitle(title)
         val fileName = if (safeTitle.endsWith(".md", true)) safeTitle else "$safeTitle.md"
-        val dirId = DocumentsContract.getDocumentId(cyanDir)
-        val existing = queryChildren(context.contentResolver, treeUri, dirId, "CyanBridge")
-            .firstOrNull { !it.isDirectory && it.name == fileName }
-        val target = existing?.uri ?: DocumentsContract.createDocument(
-            context.contentResolver,
-            cyanDir,
-            "text/markdown",
-            fileName,
-        ) ?: error("Could not create the note in the Obsidian vault.")
 
-        context.contentResolver.openOutputStream(target, "wt")?.use { output ->
+        var target = existingUri
+        if (target == null) {
+            val dirId = DocumentsContract.getDocumentId(cyanDir)
+            val existing = queryChildren(resolver, treeUri, dirId, MANAGED_NOTES_DIR)
+                .firstOrNull { !it.isDirectory && it.name.equals(fileName, ignoreCase = true) }
+            target = existing?.uri ?: DocumentsContract.createDocument(
+                resolver,
+                cyanDir,
+                "text/markdown",
+                fileName,
+            ) ?: error("Could not create the note in the Obsidian vault.")
+        } else {
+            val currentName = queryDisplayName(resolver, target)
+            if (currentName != null && !currentName.equals(fileName, ignoreCase = false)) {
+                target = DocumentsContract.renameDocument(resolver, target, fileName) ?: target
+            }
+        }
+
+        resolver.openOutputStream(target, "wt")?.use { output ->
             output.write(markdown.toByteArray(Charsets.UTF_8))
         } ?: error("Could not write the Obsidian note.")
         return target
     }
+
+    private fun resolveRootId(treeUri: Uri, rootDocumentId: String?): String =
+        rootDocumentId?.takeIf { it.isNotBlank() } ?: DocumentsContract.getTreeDocumentId(treeUri)
+
+    private fun ensureManagedNotesDirectory(
+        resolver: ContentResolver,
+        treeUri: Uri,
+        rootDocumentId: String,
+    ): Uri {
+        findManagedNotesDirectory(resolver, treeUri, rootDocumentId)?.let { return it.uri }
+        val root = DocumentsContract.buildDocumentUriUsingTree(treeUri, rootDocumentId)
+        return DocumentsContract.createDocument(
+            resolver,
+            root,
+            DocumentsContract.Document.MIME_TYPE_DIR,
+            MANAGED_NOTES_DIR,
+        ) ?: error("Could not create the CyanBridge folder in the Obsidian vault.")
+    }
+
+    private fun findManagedNotesDirectory(
+        resolver: ContentResolver,
+        treeUri: Uri,
+        rootDocumentId: String,
+    ): SafEntry? = queryChildren(resolver, treeUri, rootDocumentId, "")
+        .firstOrNull { it.isDirectory && it.name == MANAGED_NOTES_DIR }
+
+    private fun sanitizeDirectoryName(name: String): String = name.trim()
+        .replace(Regex("[\\/:*?\"<>|]"), "-")
+        .trim('.', ' ')
+        .take(80)
+        .ifBlank { "CyanBridge Vault" }
+
+    private fun sanitizeFileTitle(title: String): String = title.trim().ifBlank { "CyanBridge note" }
+        .replace(Regex("[\\/:*?\"<>|]"), "-")
+        .take(100)
 
     private fun readText(resolver: ContentResolver, uri: Uri): String? = runCatching {
         resolver.openInputStream(uri)?.use { input ->
@@ -132,10 +254,13 @@ object SafKnowledgeRepository {
         }
     }.getOrNull()
 
-    private fun listTree(resolver: ContentResolver, treeUri: Uri): List<SafEntry> {
-        val rootId = DocumentsContract.getTreeDocumentId(treeUri)
+    private fun listTree(
+        resolver: ContentResolver,
+        treeUri: Uri,
+        startDocumentId: String,
+    ): List<SafEntry> {
         val queue = ArrayDeque<Pair<String, String>>()
-        queue.add(rootId to "")
+        queue.add(startDocumentId to "")
         val out = mutableListOf<SafEntry>()
         while (queue.isNotEmpty() && out.size < MAX_FILES_PER_SCAN) {
             val (parentId, parentPath) = queue.removeFirst()
@@ -148,6 +273,16 @@ object SafKnowledgeRepository {
         }
         return out
     }
+
+    private fun queryDisplayName(resolver: ContentResolver, uri: Uri): String? = runCatching {
+        resolver.query(
+            uri,
+            arrayOf(DocumentsContract.Document.COLUMN_DISPLAY_NAME),
+            null,
+            null,
+            null,
+        )?.use { cursor -> if (cursor.moveToFirst()) cursor.getString(0) else null }
+    }.getOrNull()
 
     private fun queryChildren(
         resolver: ContentResolver,

--- a/android/CyanBridge/app/src/main/java/com/fersaiyan/cyanbridge/localagent/memory/LocalAgentMemorySearch.kt
+++ b/android/CyanBridge/app/src/main/java/com/fersaiyan/cyanbridge/localagent/memory/LocalAgentMemorySearch.kt
@@ -28,6 +28,12 @@ object LocalAgentMemorySearch {
     ): String {
         return runCatching {
             runBlocking(Dispatchers.IO) {
+                val importedAllowed = ImportedKnowledgeIndex.mayInjectIntoCurrentPrompt(context)
+                // Reserve explicit room for imported RAG when it is eligible. Without this split,
+                // the legacy memory block can consume maxChars before imported context is appended.
+                val importedBudget = if (importedAllowed) (maxChars * 0.36f).toInt().coerceAtLeast(420) else 0
+                val coreBudget = (maxChars - importedBudget).coerceAtLeast(600).coerceAtMost(maxChars)
+
                 val core = MemorySearchOrchestrator.buildRelevantMemoryBlock(
                     context = context,
                     queryText = queryText,
@@ -37,21 +43,28 @@ object LocalAgentMemorySearch {
                         topFacts = topFacts,
                         topSummaryLines = topSummaryLines,
                         topScreenHits = 3,
-                        maxChars = maxChars,
+                        maxChars = coreBudget,
                     ),
                 )
                 // Inbound integrations are intentionally local-only at prompt time.
                 // ImportedKnowledgeIndex returns an empty block whenever a relay/cloud
                 // provider is selected, so private Obsidian/ChatGPT/Claude material is
                 // never silently forwarded to an external AI service.
-                val imported = ImportedKnowledgeIndex.relevantBlock(
-                    context = context,
-                    query = queryText,
-                    maxChars = (maxChars / 2).coerceAtLeast(500),
-                )
-                listOf(core, imported).filter { it.isNotBlank() }.joinToString("\n\n").let { combined ->
-                    if (combined.length <= maxChars) combined else combined.take(maxChars).trimEnd() + "…"
+                val imported = if (importedAllowed) {
+                    ImportedKnowledgeIndex.relevantBlock(
+                        context = context,
+                        query = queryText,
+                        maxChars = importedBudget,
+                    )
+                } else {
+                    ""
                 }
+                listOf(core, imported)
+                    .filter { it.isNotBlank() }
+                    .joinToString("\n\n")
+                    .let { combined ->
+                        if (combined.length <= maxChars) combined else combined.take(maxChars).trimEnd() + "…"
+                    }
             }
         }.getOrDefault("")
     }

--- a/android/CyanBridge/app/src/main/java/com/fersaiyan/cyanbridge/localagent/memory/LocalAgentMemorySearch.kt
+++ b/android/CyanBridge/app/src/main/java/com/fersaiyan/cyanbridge/localagent/memory/LocalAgentMemorySearch.kt
@@ -1,6 +1,7 @@
 package com.fersaiyan.cyanbridge.localagent.memory
 
 import android.content.Context
+import com.fersaiyan.cyanbridge.integrations.knowledge.ImportedKnowledgeIndex
 import com.fersaiyan.cyanbridge.memoryvault.MemorySearchOrchestrator
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
@@ -27,7 +28,7 @@ object LocalAgentMemorySearch {
     ): String {
         return runCatching {
             runBlocking(Dispatchers.IO) {
-                MemorySearchOrchestrator.buildRelevantMemoryBlock(
+                val core = MemorySearchOrchestrator.buildRelevantMemoryBlock(
                     context = context,
                     queryText = queryText,
                     date = date,
@@ -39,6 +40,18 @@ object LocalAgentMemorySearch {
                         maxChars = maxChars,
                     ),
                 )
+                // Inbound integrations are intentionally local-only at prompt time.
+                // ImportedKnowledgeIndex returns an empty block whenever a relay/cloud
+                // provider is selected, so private Obsidian/ChatGPT/Claude material is
+                // never silently forwarded to an external AI service.
+                val imported = ImportedKnowledgeIndex.relevantBlock(
+                    context = context,
+                    query = queryText,
+                    maxChars = (maxChars / 2).coerceAtLeast(500),
+                )
+                listOf(core, imported).filter { it.isNotBlank() }.joinToString("\n\n").let { combined ->
+                    if (combined.length <= maxChars) combined else combined.take(maxChars).trimEnd() + "…"
+                }
             }
         }.getOrDefault("")
     }

--- a/android/CyanBridge/app/src/test/java/com/fersaiyan/cyanbridge/integrations/knowledge/ExternalAiExportParserTest.kt
+++ b/android/CyanBridge/app/src/test/java/com/fersaiyan/cyanbridge/integrations/knowledge/ExternalAiExportParserTest.kt
@@ -4,7 +4,10 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
 
+@RunWith(RobolectricTestRunner::class)
 class ExternalAiExportParserTest {
     @Test
     fun parsesChatGptConversationMappingAndSeparatesUserText() {

--- a/android/CyanBridge/app/src/test/java/com/fersaiyan/cyanbridge/integrations/knowledge/ExternalAiExportParserTest.kt
+++ b/android/CyanBridge/app/src/test/java/com/fersaiyan/cyanbridge/integrations/knowledge/ExternalAiExportParserTest.kt
@@ -1,0 +1,63 @@
+package com.fersaiyan.cyanbridge.integrations.knowledge
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ExternalAiExportParserTest {
+    @Test
+    fun parsesChatGptConversationMappingAndSeparatesUserText() {
+        val json = """
+            [
+              {
+                "id": "c1",
+                "title": "Physics notes",
+                "mapping": {
+                  "a": {"message": {"author": {"role": "user"}, "create_time": 10, "content": {"parts": ["I prefer concise equations."]}}},
+                  "b": {"message": {"author": {"role": "assistant"}, "create_time": 11, "content": {"parts": ["You always love tensors."]}}}
+                }
+              }
+            ]
+        """.trimIndent().toByteArray()
+
+        val parsed = ExternalAiExportParser.parseJson(json, "conversations.json")
+        assertEquals(KnowledgeSource.CHATGPT, parsed.source)
+        assertEquals(1, parsed.documents.size)
+        val doc = parsed.documents.single()
+        assertTrue(doc.text.contains("## User"))
+        assertTrue(doc.text.contains("## Assistant"))
+        assertTrue(doc.userAuthoredText.contains("I prefer concise equations."))
+        assertFalse(doc.userAuthoredText.contains("You always love tensors."))
+    }
+
+    @Test
+    fun parsesClaudeChatMessages() {
+        val json = """
+            [
+              {
+                "uuid": "claude-1",
+                "name": "Planning",
+                "chat_messages": [
+                  {"sender": "human", "text": "My project is CyanBridge."},
+                  {"sender": "assistant", "text": "I can help with it."}
+                ]
+              }
+            ]
+        """.trimIndent().toByteArray()
+
+        val parsed = ExternalAiExportParser.parseJson(json, "claude-export.json")
+        assertEquals(KnowledgeSource.CLAUDE, parsed.source)
+        val doc = parsed.documents.single()
+        assertEquals("Planning", doc.title)
+        assertEquals("My project is CyanBridge.", doc.userAuthoredText)
+    }
+
+    @Test
+    fun chunksLongImportedTextWithOverlap() {
+        val text = (1..900).joinToString(" ") { "token$it" }
+        val chunks = ImportedKnowledgeIndex.chunk(text)
+        assertTrue(chunks.size > 1)
+        assertTrue(chunks.all { it.length <= 2400 })
+    }
+}

--- a/android/CyanBridge/app/src/test/java/com/fersaiyan/cyanbridge/integrations/knowledge/ExternalAiExportParserTest.kt
+++ b/android/CyanBridge/app/src/test/java/com/fersaiyan/cyanbridge/integrations/knowledge/ExternalAiExportParserTest.kt
@@ -6,8 +6,10 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
 
 @RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
 class ExternalAiExportParserTest {
     @Test
     fun parsesChatGptConversationMappingAndSeparatesUserText() {

--- a/android/CyanBridge/app/src/test/java/com/fersaiyan/cyanbridge/integrations/knowledge/ObsidianMarkdownEditorTest.kt
+++ b/android/CyanBridge/app/src/test/java/com/fersaiyan/cyanbridge/integrations/knowledge/ObsidianMarkdownEditorTest.kt
@@ -1,0 +1,46 @@
+package com.fersaiyan.cyanbridge.integrations.knowledge
+
+import androidx.compose.ui.text.TextRange
+import androidx.compose.ui.text.input.TextFieldValue
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ObsidianMarkdownEditorTest {
+    @Test
+    fun renderAndParsePreserveManagedMetadata() {
+        val rendered = ObsidianMarkdownCodec.render(
+            ObsidianManagedDraft(
+                title = "Project plan",
+                tags = "#cyanbridge, research research",
+                body = "- [ ] Ship it\n- [x] Test it",
+                createdAt = "2026-08-20 10:00",
+            ),
+            now = "2026-08-26 01:30",
+        )
+
+        assertTrue(rendered.contains("created: \"2026-08-20 10:00\""))
+        assertTrue(rendered.contains("updated: \"2026-08-26 01:30\""))
+        assertTrue(rendered.contains("tags: [cyanbridge, research]"))
+
+        val parsed = ObsidianMarkdownCodec.parse("Project plan.md", rendered)
+        assertEquals("Project plan", parsed.title)
+        assertEquals("cyanbridge, research", parsed.tags)
+        assertEquals("2026-08-20 10:00", parsed.createdAt)
+        assertTrue(parsed.body.contains("- [ ] Ship it"))
+    }
+
+    @Test
+    fun wrapsSelectedMarkdownText() {
+        val original = TextFieldValue("hello world", selection = TextRange(6, 11))
+        val bold = MarkdownEditorActions.wrap(original, "**", "**", "bold")
+        assertEquals("hello **world**", bold.text)
+    }
+
+    @Test
+    fun prefixesCurrentLineForTaskLists() {
+        val original = TextFieldValue("first\nsecond", selection = TextRange(9))
+        val task = MarkdownEditorActions.prefixCurrentLine(original, "- [ ] ")
+        assertEquals("first\n- [ ] second", task.text)
+    }
+}

--- a/android/CyanBridge/docs/personal-knowledge-integrations.md
+++ b/android/CyanBridge/docs/personal-knowledge-integrations.md
@@ -1,10 +1,10 @@
 # Personal knowledge integrations: Obsidian, ChatGPT, Claude
 
-Status: initial Android implementation on `obsidian-chatgpt-claude-integrations`.
+Status: Android implementation on `obsidian-chatgpt-claude-integrations`.
 
 ## Product goal
 
-CyanBridge should be a private personal-AI memory layer, not a replacement for every assistant the user already likes. External assistants and note apps are therefore **inbound knowledge sources**. CyanBridge can learn from material the user explicitly grants, while CyanBridge chats, private memory, notes, images, and other local context are never synchronized back to ChatGPT or Claude by this integration.
+CyanBridge should be a private personal-AI memory layer, not a replacement for every assistant or note app the user already likes. External assistants and note apps are therefore **inbound knowledge sources**. CyanBridge can learn from material the user explicitly grants, while CyanBridge chats, private memory, images, and other local context are never synchronized back to ChatGPT or Claude by this integration.
 
 ## Current provider reality (August 2026)
 
@@ -21,20 +21,38 @@ Official references:
 
 ### 1. Official exports for backfill
 
-The user can import a ChatGPT or Claude export ZIP/JSON. Parsing is local. Conversations become provider-tagged FTS chunks. User-authored turns are also retained separately in the parser model so future fact-candidate extraction never treats an assistant assertion as a user fact.
+The user can import a ChatGPT or Claude export ZIP/JSON. Parsing is local. Conversations become provider-tagged FTS chunks. User-authored turns are retained separately in the parser model so future fact-candidate extraction never treats an assistant assertion as a user fact.
 
 This is best for first-time onboarding and occasional full reconciliation, not daily sync.
 
-### 2. Obsidian as a two-way knowledge store
+### 2. Obsidian / Markdown vault as a two-way knowledge store
 
-Android's Storage Access Framework lets the user grant CyanBridge access to one selected vault tree without broad storage permission. CyanBridge can:
+Android's Storage Access Framework lets the user grant CyanBridge access to one selected folder tree without broad storage permission. A vault is considered connected only after CyanBridge confirms that retained **read and write** permission exists.
+
+The setup UI supports two cases:
+
+- **Connect existing vault:** the user selects an existing Obsidian vault folder and Android grants scoped read/write access to that tree.
+- **Create new vault:** the user enters a vault name, selects a parent location, and CyanBridge creates a normal Markdown vault folder there. CyanBridge stores the selected parent permission plus the created vault document ID as the logical root, so no all-files permission is needed.
+
+CyanBridge can then:
 
 - recursively index Markdown notes while skipping `.obsidian`/hidden metadata;
-- write new Markdown notes to `<vault>/CyanBridge/`;
+- create a `CyanBridge/` folder for notes managed from the app;
+- create and update notes in that managed folder;
+- list recent CyanBridge-managed notes and reopen them in the editor;
+- preserve CyanBridge note creation metadata when editing;
+- write Obsidian-compatible YAML tags;
+- provide editor shortcuts for headings, bullet/numbered lists, task checkboxes, bold, italic, inline code, quotes, links, wiki links, and inline tags;
 - re-index after a note is saved;
-- periodically re-index the granted tree with WorkManager.
+- periodically re-index the granted vault with WorkManager.
 
-This lets users keep Obsidian as their canonical note app while CyanBridge can answer questions about the same material.
+Other Markdown files in the vault remain readable/searchable but are not overwritten by the CyanBridge note editor. This makes the `CyanBridge/` folder a safe managed namespace while the rest of the vault remains under the user's normal Obsidian workflow.
+
+#### Important encryption boundary
+
+Obsidian compatibility requires the source files in the external vault to remain ordinary plaintext `.md` files. **CyanBridge Memory Vault encryption does not encrypt those external Markdown files.** The UI states this explicitly rather than implying that enabling app-vault encryption also protects Obsidian source files.
+
+Users who need encryption at rest for the external vault should rely on device/storage encryption or an encrypted storage/sync provider that remains compatible with their Obsidian workflow. CyanBridge may keep a local searchable index of granted notes inside app storage, but that internal index and the external `.md` source files are separate storage layers.
 
 ### 3. Import Inbox as the automation boundary
 
@@ -69,7 +87,7 @@ A follow-up fact-candidate pipeline should operate only on `KnowledgeDocument.us
 
 ## Chat rendering
 
-The shared chat surface now uses a dependency-free KMP Markdown renderer for the patterns generated most often by LLMs: headings, lists, quotes, fenced/inline code, bold, italic, bold+italic, strike-through, links, inline math, and display math. Common LaTeX commands are converted to readable Unicode locally so math remains usable offline without a WebView or remote MathJax dependency.
+The shared chat surface uses a dependency-free KMP Markdown renderer for the patterns generated most often by LLMs: headings, lists, quotes, fenced/inline code, bold, italic, bold+italic, strike-through, links, inline math, and display math. Common LaTeX commands are converted to readable Unicode locally so math remains usable offline without a WebView or remote MathJax dependency.
 
 The parser is intentionally conservative. Unknown LaTeX commands remain visible rather than being dropped. A richer native math layout engine can replace the normalizer later without changing chat-message storage.
 
@@ -78,6 +96,6 @@ The parser is intentionally conservative. Unknown LaTeX commands remain visible 
 - browser/desktop companion that incrementally writes changed ChatGPT/Claude conversations to the Import Inbox;
 - explicit local-only "Extract fact candidates from imports" review flow;
 - incremental file fingerprints so large Obsidian vaults only re-read changed files;
-- browse/edit existing Obsidian notes from the CyanBridge Notes screen;
+- search/browse the entire Obsidian vault from CyanBridge while continuing to restrict write-editing to the managed `CyanBridge/` namespace;
 - iOS document-tree equivalent and shared integration UI;
-- encrypted cross-device sync of normalized external knowledge for users who opt into CyanBridge encrypted sync.
+- optional encrypted cross-device sync of normalized external knowledge, without attempting to encrypt the Obsidian source vault itself.

--- a/android/CyanBridge/docs/personal-knowledge-integrations.md
+++ b/android/CyanBridge/docs/personal-knowledge-integrations.md
@@ -1,0 +1,83 @@
+# Personal knowledge integrations: Obsidian, ChatGPT, Claude
+
+Status: initial Android implementation on `obsidian-chatgpt-claude-integrations`.
+
+## Product goal
+
+CyanBridge should be a private personal-AI memory layer, not a replacement for every assistant the user already likes. External assistants and note apps are therefore **inbound knowledge sources**. CyanBridge can learn from material the user explicitly grants, while CyanBridge chats, private memory, notes, images, and other local context are never synchronized back to ChatGPT or Claude by this integration.
+
+## Current provider reality (August 2026)
+
+Consumer ChatGPT and Claude account history is exposed through account data-export flows, not a documented OAuth-style API that lets another Android app continuously enumerate a user's consumer chat history. The initial integration therefore avoids undocumented session-cookie/token scraping.
+
+Official references:
+
+- OpenAI data export: https://help.openai.com/en/articles/7260999-how-do-i-export-my-chatgpt-history-and-data
+- OpenAI export transfer notes (`conversations.json`): https://help.openai.com/en/articles/9106926-transfer-conversations-from-1-chatgpt-account-to-another-chatgpt-account
+- Claude data export: https://support.claude.com/en/articles/9450526-export-your-claude-data
+- Android Storage Access Framework: https://developer.android.com/training/data-storage/shared/documents-files
+
+## Architecture
+
+### 1. Official exports for backfill
+
+The user can import a ChatGPT or Claude export ZIP/JSON. Parsing is local. Conversations become provider-tagged FTS chunks. User-authored turns are also retained separately in the parser model so future fact-candidate extraction never treats an assistant assertion as a user fact.
+
+This is best for first-time onboarding and occasional full reconciliation, not daily sync.
+
+### 2. Obsidian as a two-way knowledge store
+
+Android's Storage Access Framework lets the user grant CyanBridge access to one selected vault tree without broad storage permission. CyanBridge can:
+
+- recursively index Markdown notes while skipping `.obsidian`/hidden metadata;
+- write new Markdown notes to `<vault>/CyanBridge/`;
+- re-index after a note is saved;
+- periodically re-index the granted tree with WorkManager.
+
+This lets users keep Obsidian as their canonical note app while CyanBridge can answer questions about the same material.
+
+### 3. Import Inbox as the automation boundary
+
+The user may grant a second folder as an **Import Inbox**. CyanBridge periodically scans supported `.zip`, `.json`, `.md`, and `.txt` files there. This creates a provider-neutral automation boundary for tools outside Android.
+
+A future CyanBridge desktop/browser companion can write normalized conversation snapshots into this folder (or a folder synchronized to it by Syncthing/FolderSync/etc.). That companion should:
+
+1. run only after explicit user opt-in;
+2. read conversations the user can already view in the browser;
+3. never transmit browser cookies/session tokens to CyanBridge servers;
+4. normalize messages locally into a simple source/conversation/role/timestamp/text schema;
+5. write only changed conversations to the user's chosen sync location;
+6. allow per-site and per-conversation exclusion.
+
+This is a better long-term daily-sync mechanism than teaching the Android app to scrape private provider endpoints or store provider credentials.
+
+### 4. Local RAG boundary
+
+Imported chunks share CyanBridge's Room FTS/Memory Vault policy path, but prompt injection is deliberately stricter than ordinary indexing:
+
+- imported material is searchable/indexed locally regardless of the current inference provider;
+- imported material is appended to model prompt context only when `AiProviderType.LOCAL_MODELS` is selected;
+- selecting CLI relay/company/cloud routing returns an empty imported-context block.
+
+This enforces the product rule that imported personal knowledge does not silently flow back out to an external assistant.
+
+### 5. Facts are derived, not copied blindly
+
+The raw imported corpus and confirmed user facts are separate concepts. ChatGPT/Claude assistant answers can be wrong, speculative, or stale, so they should never directly become durable personal facts.
+
+A follow-up fact-candidate pipeline should operate only on `KnowledgeDocument.userAuthoredText`, run with an on-device model, write to the existing candidate-review stores, and preserve source provenance. Historical imports should not automatically create "today" daily facts; candidates need original-message timestamps or an explicit review UI before promotion.
+
+## Chat rendering
+
+The shared chat surface now uses a dependency-free KMP Markdown renderer for the patterns generated most often by LLMs: headings, lists, quotes, fenced/inline code, bold, italic, bold+italic, strike-through, links, inline math, and display math. Common LaTeX commands are converted to readable Unicode locally so math remains usable offline without a WebView or remote MathJax dependency.
+
+The parser is intentionally conservative. Unknown LaTeX commands remain visible rather than being dropped. A richer native math layout engine can replace the normalizer later without changing chat-message storage.
+
+## Next phases
+
+- browser/desktop companion that incrementally writes changed ChatGPT/Claude conversations to the Import Inbox;
+- explicit local-only "Extract fact candidates from imports" review flow;
+- incremental file fingerprints so large Obsidian vaults only re-read changed files;
+- browse/edit existing Obsidian notes from the CyanBridge Notes screen;
+- iOS document-tree equivalent and shared integration UI;
+- encrypted cross-device sync of normalized external knowledge for users who opt into CyanBridge encrypted sync.

--- a/android/CyanBridge/shared/src/androidMain/kotlin/com/fersaiyan/cyanbridge/shared/ui/chat/PlatformKnowledgeIntegrationsMenuItem.android.kt
+++ b/android/CyanBridge/shared/src/androidMain/kotlin/com/fersaiyan/cyanbridge/shared/ui/chat/PlatformKnowledgeIntegrationsMenuItem.android.kt
@@ -1,0 +1,35 @@
+package com.fersaiyan.cyanbridge.shared.ui.chat
+
+import android.content.Intent
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.style.TextAlign
+
+@Composable
+actual fun PlatformKnowledgeIntegrationsMenuItem(onDismissRequest: () -> Unit) {
+    val context = LocalContext.current
+    TextButton(
+        onClick = {
+            onDismissRequest()
+            val intent = Intent().setClassName(
+                context.packageName,
+                "com.fersaiyan.cyanbridge.integrations.knowledge.KnowledgeIntegrationsActivity",
+            )
+            context.startActivity(intent)
+        },
+        modifier = Modifier
+            .fillMaxWidth()
+            .testTag("chat_action_knowledge_integrations"),
+    ) {
+        Text(
+            text = "Notes & AI imports",
+            modifier = Modifier.fillMaxWidth(),
+            textAlign = TextAlign.Start,
+        )
+    }
+}

--- a/android/CyanBridge/shared/src/commonMain/kotlin/com/fersaiyan/cyanbridge/shared/ui/chat/ChatAppearanceMenuDialog.kt
+++ b/android/CyanBridge/shared/src/commonMain/kotlin/com/fersaiyan/cyanbridge/shared/ui/chat/ChatAppearanceMenuDialog.kt
@@ -34,6 +34,7 @@ fun ChatAppearanceMenuDialog(
         title = { Text(stringResource(Res.string.chat_appearance)) },
         text = {
             Column(modifier = Modifier.fillMaxWidth()) {
+                PlatformKnowledgeIntegrationsMenuItem(onDismissRequest)
                 ChatAppearanceMenuItem(
                      label = stringResource(Res.string.chat_change_user_bubble),
                     action = ChatAppearanceMenuAction.CHANGE_USER_BUBBLE_COLOR,

--- a/android/CyanBridge/shared/src/commonMain/kotlin/com/fersaiyan/cyanbridge/shared/ui/chat/ChatRichText.kt
+++ b/android/CyanBridge/shared/src/commonMain/kotlin/com/fersaiyan/cyanbridge/shared/ui/chat/ChatRichText.kt
@@ -1,0 +1,388 @@
+package com.fersaiyan.cyanbridge.shared.ui.chat
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.unit.dp
+
+/**
+ * Small dependency-free Markdown renderer for chat output.
+ *
+ * Chat responses are streamed and the shared UI is Kotlin Multiplatform, so this deliberately
+ * keeps parsing deterministic and cheap. It supports the formatting LLMs use most often:
+ * headings, paragraphs, bullets, numbered lists, blockquotes, fenced code, bold/italic/
+ * bold-italic, strike-through, inline code, links, and readable LaTeX-style math.
+ *
+ * LaTeX is normalized into Unicode where that is safe (Greek symbols, operators, simple
+ * fractions/square roots/super- and subscripts). Unknown commands remain visible instead of
+ * disappearing. This is preferable to a WebView/remote MathJax dependency for a private,
+ * offline-first chat surface.
+ */
+@Composable
+fun ChatRichText(
+    markdown: String,
+    color: Color,
+    modifier: Modifier = Modifier,
+) {
+    val blocks = ChatMarkdownParser.parse(markdown)
+    Column(modifier = modifier, verticalArrangement = androidx.compose.foundation.layout.Arrangement.spacedBy(6.dp)) {
+        blocks.forEach { block ->
+            when (block) {
+                is ChatMarkdownBlock.Heading -> Text(
+                    text = richInline(block.text),
+                    color = color,
+                    style = when (block.level) {
+                        1 -> MaterialTheme.typography.titleLarge
+                        2 -> MaterialTheme.typography.titleMedium
+                        else -> MaterialTheme.typography.titleSmall
+                    },
+                    fontWeight = FontWeight.SemiBold,
+                )
+
+                is ChatMarkdownBlock.Paragraph -> Text(
+                    text = richInline(block.text),
+                    color = color,
+                    style = MaterialTheme.typography.bodyLarge,
+                )
+
+                is ChatMarkdownBlock.ListItem -> Text(
+                    text = richInline("${block.prefix} ${block.text}"),
+                    color = color,
+                    style = MaterialTheme.typography.bodyLarge,
+                )
+
+                is ChatMarkdownBlock.Quote -> Text(
+                    text = richInline("▌ ${block.text}"),
+                    color = color.copy(alpha = 0.88f),
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontStyle = FontStyle.Italic,
+                )
+
+                is ChatMarkdownBlock.Code -> Text(
+                    text = block.code,
+                    color = color,
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontFamily = FontFamily.Monospace,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .background(color.copy(alpha = 0.10f), RoundedCornerShape(8.dp))
+                        .padding(10.dp),
+                )
+
+                is ChatMarkdownBlock.Math -> Text(
+                    text = normalizeLatex(block.formula),
+                    color = color,
+                    style = MaterialTheme.typography.bodyLarge,
+                    fontFamily = FontFamily.Monospace,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .background(color.copy(alpha = 0.08f), RoundedCornerShape(8.dp))
+                        .padding(horizontal = 10.dp, vertical = 8.dp),
+                )
+            }
+        }
+    }
+}
+
+internal sealed interface ChatMarkdownBlock {
+    data class Heading(val level: Int, val text: String) : ChatMarkdownBlock
+    data class Paragraph(val text: String) : ChatMarkdownBlock
+    data class ListItem(val prefix: String, val text: String) : ChatMarkdownBlock
+    data class Quote(val text: String) : ChatMarkdownBlock
+    data class Code(val code: String, val language: String?) : ChatMarkdownBlock
+    data class Math(val formula: String) : ChatMarkdownBlock
+}
+
+internal object ChatMarkdownParser {
+    private val heading = Regex("^(#{1,6})\\s+(.+)$")
+    private val unordered = Regex("^\\s*[-+*]\\s+(.+)$")
+    private val ordered = Regex("^\\s*(\\d+)[.)]\\s+(.+)$")
+
+    fun parse(markdown: String): List<ChatMarkdownBlock> {
+        if (markdown.isBlank()) return listOf(ChatMarkdownBlock.Paragraph(""))
+
+        val out = mutableListOf<ChatMarkdownBlock>()
+        val paragraph = mutableListOf<String>()
+        val code = mutableListOf<String>()
+        val math = mutableListOf<String>()
+        var codeLanguage: String? = null
+        var inCode = false
+        var inMath = false
+
+        fun flushParagraph() {
+            if (paragraph.isNotEmpty()) {
+                out += ChatMarkdownBlock.Paragraph(paragraph.joinToString("\n").trim())
+                paragraph.clear()
+            }
+        }
+        fun flushCode() {
+            out += ChatMarkdownBlock.Code(code.joinToString("\n").trimEnd(), codeLanguage)
+            code.clear()
+            codeLanguage = null
+        }
+        fun flushMath() {
+            out += ChatMarkdownBlock.Math(math.joinToString("\n").trim())
+            math.clear()
+        }
+
+        markdown.replace("\r\n", "\n").replace('\r', '\n').lines().forEach { raw ->
+            val line = raw.trimEnd()
+            val trimmed = line.trim()
+
+            if (inCode) {
+                if (trimmed.startsWith("```")) {
+                    inCode = false
+                    flushCode()
+                } else {
+                    code += line
+                }
+                return@forEach
+            }
+
+            if (inMath) {
+                val end = trimmed.indexOf("$$")
+                if (end >= 0) {
+                    math += trimmed.substring(0, end)
+                    inMath = false
+                    flushMath()
+                    val remainder = trimmed.substring(end + 2).trim()
+                    if (remainder.isNotEmpty()) paragraph += remainder
+                } else {
+                    math += line
+                }
+                return@forEach
+            }
+
+            if (trimmed.startsWith("```")) {
+                flushParagraph()
+                inCode = true
+                codeLanguage = trimmed.removePrefix("```").trim().ifBlank { null }
+                return@forEach
+            }
+
+            if (trimmed.startsWith("$$")) {
+                flushParagraph()
+                val rest = trimmed.removePrefix("$$")
+                val closing = rest.indexOf("$$")
+                if (closing >= 0) {
+                    out += ChatMarkdownBlock.Math(rest.substring(0, closing).trim())
+                    val remainder = rest.substring(closing + 2).trim()
+                    if (remainder.isNotEmpty()) paragraph += remainder
+                } else {
+                    inMath = true
+                    if (rest.isNotBlank()) math += rest
+                }
+                return@forEach
+            }
+
+            if (trimmed.startsWith("\\[") && trimmed.endsWith("\\]") && trimmed.length >= 4) {
+                flushParagraph()
+                out += ChatMarkdownBlock.Math(trimmed.removePrefix("\\[").removeSuffix("\\]").trim())
+                return@forEach
+            }
+
+            if (trimmed.isBlank()) {
+                flushParagraph()
+                return@forEach
+            }
+
+            heading.matchEntire(trimmed)?.let { match ->
+                flushParagraph()
+                out += ChatMarkdownBlock.Heading(match.groupValues[1].length, match.groupValues[2].trim())
+                return@forEach
+            }
+            unordered.matchEntire(line)?.let { match ->
+                flushParagraph()
+                out += ChatMarkdownBlock.ListItem("•", match.groupValues[1].trim())
+                return@forEach
+            }
+            ordered.matchEntire(line)?.let { match ->
+                flushParagraph()
+                out += ChatMarkdownBlock.ListItem("${match.groupValues[1]}.", match.groupValues[2].trim())
+                return@forEach
+            }
+            if (trimmed.startsWith(">")) {
+                flushParagraph()
+                out += ChatMarkdownBlock.Quote(trimmed.removePrefix(">").trim())
+                return@forEach
+            }
+
+            paragraph += line
+        }
+
+        if (inCode) flushCode()
+        if (inMath) flushMath()
+        flushParagraph()
+        return out.ifEmpty { listOf(ChatMarkdownBlock.Paragraph(markdown)) }
+    }
+}
+
+private fun richInline(text: String): AnnotatedString = buildAnnotatedString {
+    appendInline(this, text, 0, text.length)
+}
+
+private data class InlineDelimiter(
+    val marker: String,
+    val style: SpanStyle,
+)
+
+private val inlineDelimiters = listOf(
+    InlineDelimiter("***", SpanStyle(fontWeight = FontWeight.Bold, fontStyle = FontStyle.Italic)),
+    InlineDelimiter("___", SpanStyle(fontWeight = FontWeight.Bold, fontStyle = FontStyle.Italic)),
+    InlineDelimiter("**", SpanStyle(fontWeight = FontWeight.Bold)),
+    InlineDelimiter("__", SpanStyle(fontWeight = FontWeight.Bold)),
+    InlineDelimiter("~~", SpanStyle(textDecoration = TextDecoration.LineThrough)),
+    InlineDelimiter("*", SpanStyle(fontStyle = FontStyle.Italic)),
+    InlineDelimiter("_", SpanStyle(fontStyle = FontStyle.Italic)),
+)
+
+private fun appendInline(builder: AnnotatedString.Builder, text: String, from: Int, to: Int) {
+    var cursor = from
+    while (cursor < to) {
+        val inlineCodeStart = text.indexOf('`', cursor).takeIf { it in cursor until to }
+        val inlineMathStart = text.indexOf('$', cursor).takeIf { it in cursor until to }
+        val linkStart = text.indexOf('[', cursor).takeIf { it in cursor until to }
+        val styled = inlineDelimiters.mapNotNull { delimiter ->
+            val start = text.indexOf(delimiter.marker, cursor)
+            if (start !in cursor until to) return@mapNotNull null
+            val end = text.indexOf(delimiter.marker, start + delimiter.marker.length)
+            if (end <= start || end >= to) return@mapNotNull null
+            Triple(start, end, delimiter)
+        }.minByOrNull { it.first }
+
+        val candidates = listOfNotNull(
+            inlineCodeStart?.let { it to "code" },
+            inlineMathStart?.let { it to "math" },
+            linkStart?.let { it to "link" },
+            styled?.let { it.first to "style" },
+        )
+        val next = candidates.minByOrNull { it.first }
+        if (next == null) {
+            builder.append(normalizeInlineLatex(text.substring(cursor, to)))
+            break
+        }
+        if (next.first > cursor) {
+            builder.append(normalizeInlineLatex(text.substring(cursor, next.first)))
+        }
+
+        when (next.second) {
+            "code" -> {
+                val end = text.indexOf('`', next.first + 1)
+                if (end <= next.first || end >= to) {
+                    builder.append("`")
+                    cursor = next.first + 1
+                } else {
+                    builder.pushStyle(SpanStyle(fontFamily = FontFamily.Monospace, background = Color.Black.copy(alpha = 0.10f)))
+                    builder.append(text.substring(next.first + 1, end))
+                    builder.pop()
+                    cursor = end + 1
+                }
+            }
+
+            "math" -> {
+                val end = text.indexOf('$', next.first + 1)
+                if (end <= next.first + 1 || end >= to) {
+                    builder.append("$")
+                    cursor = next.first + 1
+                } else {
+                    builder.pushStyle(SpanStyle(fontFamily = FontFamily.Monospace))
+                    builder.append(normalizeLatex(text.substring(next.first + 1, end)))
+                    builder.pop()
+                    cursor = end + 1
+                }
+            }
+
+            "link" -> {
+                val closeText = text.indexOf(']', next.first + 1)
+                val openUrl = if (closeText >= 0) text.indexOf('(', closeText + 1) else -1
+                val closeUrl = if (openUrl >= 0) text.indexOf(')', openUrl + 1) else -1
+                if (closeText in (next.first + 1) until to && openUrl == closeText + 1 && closeUrl in (openUrl + 1) until to) {
+                    builder.pushStyle(SpanStyle(textDecoration = TextDecoration.Underline))
+                    appendInline(builder, text, next.first + 1, closeText)
+                    builder.pop()
+                    cursor = closeUrl + 1
+                } else {
+                    builder.append("[")
+                    cursor = next.first + 1
+                }
+            }
+
+            else -> {
+                val match = styled
+                if (match == null || match.first != next.first) {
+                    builder.append(text[next.first].toString())
+                    cursor = next.first + 1
+                } else {
+                    val delimiter = match.third
+                    builder.pushStyle(delimiter.style)
+                    appendInline(builder, text, match.first + delimiter.marker.length, match.second)
+                    builder.pop()
+                    cursor = match.second + delimiter.marker.length
+                }
+            }
+        }
+    }
+}
+
+private fun normalizeInlineLatex(text: String): String {
+    if ('\\' !in text && '^' !in text && '_' !in text) return text
+    return normalizeLatex(text)
+}
+
+internal fun normalizeLatex(input: String): String {
+    var out = input.trim()
+    val replacements = linkedMapOf(
+        "\\alpha" to "α", "\\beta" to "β", "\\gamma" to "γ", "\\delta" to "δ",
+        "\\epsilon" to "ε", "\\theta" to "θ", "\\lambda" to "λ", "\\mu" to "μ",
+        "\\pi" to "π", "\\rho" to "ρ", "\\sigma" to "σ", "\\phi" to "φ",
+        "\\omega" to "ω", "\\Gamma" to "Γ", "\\Delta" to "Δ", "\\Theta" to "Θ",
+        "\\Lambda" to "Λ", "\\Pi" to "Π", "\\Sigma" to "Σ", "\\Phi" to "Φ", "\\Omega" to "Ω",
+        "\\times" to "×", "\\cdot" to "·", "\\pm" to "±", "\\leq" to "≤", "\\le" to "≤",
+        "\\geq" to "≥", "\\ge" to "≥", "\\neq" to "≠", "\\approx" to "≈", "\\infty" to "∞",
+        "\\to" to "→", "\\rightarrow" to "→", "\\leftarrow" to "←", "\\sum" to "∑", "\\prod" to "∏",
+        "\\int" to "∫", "\\partial" to "∂", "\\nabla" to "∇", "\\in" to "∈", "\\notin" to "∉",
+    )
+    replacements.forEach { (source, target) -> out = out.replace(source, target) }
+    out = out.replace("\\left", "").replace("\\right", "")
+
+    val fraction = Regex("\\\\frac\\{([^{}]+)}\\{([^{}]+)}")
+    repeat(4) { out = fraction.replace(out) { match -> "(${match.groupValues[1]})/(${match.groupValues[2]})" } }
+    val sqrt = Regex("\\\\sqrt\\{([^{}]+)}")
+    out = sqrt.replace(out) { match -> "√(${match.groupValues[1]})" }
+
+    val superscript = mapOf(
+        '0' to '⁰', '1' to '¹', '2' to '²', '3' to '³', '4' to '⁴', '5' to '⁵',
+        '6' to '⁶', '7' to '⁷', '8' to '⁸', '9' to '⁹', '+' to '⁺', '-' to '⁻',
+        '=' to '⁼', '(' to '⁽', ')' to '⁾', 'n' to 'ⁿ', 'i' to 'ⁱ',
+    )
+    val subscript = mapOf(
+        '0' to '₀', '1' to '₁', '2' to '₂', '3' to '₃', '4' to '₄', '5' to '₅',
+        '6' to '₆', '7' to '₇', '8' to '₈', '9' to '₉', '+' to '₊', '-' to '₋',
+        '=' to '₌', '(' to '₍', ')' to '₎', 'a' to 'ₐ', 'e' to 'ₑ', 'h' to 'ₕ', 'i' to 'ᵢ',
+        'j' to 'ⱼ', 'k' to 'ₖ', 'l' to 'ₗ', 'm' to 'ₘ', 'n' to 'ₙ', 'o' to 'ₒ', 'p' to 'ₚ',
+        'r' to 'ᵣ', 's' to 'ₛ', 't' to 'ₜ', 'u' to 'ᵤ', 'v' to 'ᵥ', 'x' to 'ₓ',
+    )
+    fun convertScript(value: String, table: Map<Char, Char>): String? {
+        val converted = value.map { table[it] ?: return null }
+        return converted.joinToString("")
+    }
+    out = Regex("\\^\\{([^{}]+)}").replace(out) { m -> convertScript(m.groupValues[1], superscript) ?: "^(${m.groupValues[1]})" }
+    out = Regex("_\\{([^{}]+)}").replace(out) { m -> convertScript(m.groupValues[1], subscript) ?: "_(${m.groupValues[1]})" }
+    out = Regex("\\^([0-9n+-])").replace(out) { m -> superscript[m.groupValues[1][0]]?.toString() ?: m.value }
+    out = Regex("_([0-9aehijklmnoprstuvx+-])").replace(out) { m -> subscript[m.groupValues[1][0]]?.toString() ?: m.value }
+    return out
+}

--- a/android/CyanBridge/shared/src/commonMain/kotlin/com/fersaiyan/cyanbridge/shared/ui/chat/ChatThreadScreen.kt
+++ b/android/CyanBridge/shared/src/commonMain/kotlin/com/fersaiyan/cyanbridge/shared/ui/chat/ChatThreadScreen.kt
@@ -374,10 +374,10 @@ private fun ChatMessageBubble(
                 contentColor = contentColor,
                 shape = shape,
             ) {
-                Text(
-                    text = message.content,
+                ChatRichText(
+                    markdown = message.content,
+                    color = contentColor,
                     modifier = Modifier.padding(horizontal = 14.dp, vertical = 10.dp),
-                    style = MaterialTheme.typography.bodyLarge,
                 )
             }
         }

--- a/android/CyanBridge/shared/src/commonMain/kotlin/com/fersaiyan/cyanbridge/shared/ui/chat/PlatformKnowledgeIntegrationsMenuItem.kt
+++ b/android/CyanBridge/shared/src/commonMain/kotlin/com/fersaiyan/cyanbridge/shared/ui/chat/PlatformKnowledgeIntegrationsMenuItem.kt
@@ -1,0 +1,7 @@
+package com.fersaiyan.cyanbridge.shared.ui.chat
+
+import androidx.compose.runtime.Composable
+
+/** Platform hook so shared chat UI can expose Android-only integration management for now. */
+@Composable
+expect fun PlatformKnowledgeIntegrationsMenuItem(onDismissRequest: () -> Unit)

--- a/android/CyanBridge/shared/src/commonTest/kotlin/com/fersaiyan/cyanbridge/shared/ui/chat/ChatRichTextTest.kt
+++ b/android/CyanBridge/shared/src/commonTest/kotlin/com/fersaiyan/cyanbridge/shared/ui/chat/ChatRichTextTest.kt
@@ -8,6 +8,7 @@ import kotlin.test.assertTrue
 class ChatRichTextTest {
     @Test
     fun parsesCommonLlmMarkdownBlocks() {
+        val dollar = '$'
         val blocks = ChatMarkdownParser.parse(
             """
             # Result
@@ -19,7 +20,7 @@ class ChatRichTextTest {
             val answer = 42
             ```
 
-            $$E = mc^2$$
+            ${dollar}${dollar}E = mc^2${dollar}${dollar}
             """.trimIndent()
         )
 

--- a/android/CyanBridge/shared/src/commonTest/kotlin/com/fersaiyan/cyanbridge/shared/ui/chat/ChatRichTextTest.kt
+++ b/android/CyanBridge/shared/src/commonTest/kotlin/com/fersaiyan/cyanbridge/shared/ui/chat/ChatRichTextTest.kt
@@ -1,0 +1,49 @@
+package com.fersaiyan.cyanbridge.shared.ui.chat
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+class ChatRichTextTest {
+    @Test
+    fun parsesCommonLlmMarkdownBlocks() {
+        val blocks = ChatMarkdownParser.parse(
+            """
+            # Result
+
+            - first
+            2. second
+
+            ```kotlin
+            val answer = 42
+            ```
+
+            $$E = mc^2$$
+            """.trimIndent()
+        )
+
+        assertIs<ChatMarkdownBlock.Heading>(blocks[0])
+        assertIs<ChatMarkdownBlock.ListItem>(blocks[1])
+        assertIs<ChatMarkdownBlock.ListItem>(blocks[2])
+        assertIs<ChatMarkdownBlock.Code>(blocks[3])
+        assertIs<ChatMarkdownBlock.Math>(blocks[4])
+    }
+
+    @Test
+    fun normalizesCommonLatexWithoutWebRendering() {
+        val normalized = normalizeLatex("\\frac{1}{2} + \\alpha_1 + x^2 \\leq \\infty")
+        assertTrue(normalized.contains("(1)/(2)"))
+        assertTrue(normalized.contains("α₁"))
+        assertTrue(normalized.contains("x²"))
+        assertTrue(normalized.contains("≤"))
+        assertTrue(normalized.contains("∞"))
+    }
+
+    @Test
+    fun incompleteStreamingFenceRemainsReadable() {
+        val blocks = ChatMarkdownParser.parse("```python\nprint('streaming')")
+        val code = assertIs<ChatMarkdownBlock.Code>(blocks.single())
+        assertEquals("print('streaming')", code.code)
+    }
+}

--- a/android/CyanBridge/shared/src/iosMain/kotlin/com/fersaiyan/cyanbridge/shared/ui/chat/PlatformKnowledgeIntegrationsMenuItem.ios.kt
+++ b/android/CyanBridge/shared/src/iosMain/kotlin/com/fersaiyan/cyanbridge/shared/ui/chat/PlatformKnowledgeIntegrationsMenuItem.ios.kt
@@ -1,0 +1,6 @@
+package com.fersaiyan.cyanbridge.shared.ui.chat
+
+import androidx.compose.runtime.Composable
+
+@Composable
+actual fun PlatformKnowledgeIntegrationsMenuItem(onDismissRequest: () -> Unit) = Unit

--- a/android/CyanBridge/shared/src/portabilityMain/kotlin/com/fersaiyan/cyanbridge/shared/ui/chat/PlatformKnowledgeIntegrationsMenuItem.portability.kt
+++ b/android/CyanBridge/shared/src/portabilityMain/kotlin/com/fersaiyan/cyanbridge/shared/ui/chat/PlatformKnowledgeIntegrationsMenuItem.portability.kt
@@ -1,0 +1,6 @@
+package com.fersaiyan.cyanbridge.shared.ui.chat
+
+import androidx.compose.runtime.Composable
+
+@Composable
+actual fun PlatformKnowledgeIntegrationsMenuItem(onDismissRequest: () -> Unit) = Unit


### PR DESCRIPTION
## Summary
- add inbound-only ChatGPT and Claude export parsing and local FTS indexing
- add scoped Obsidian/Markdown vault integration using Android Storage Access Framework
- require retained read/write permission before a vault is considered connected
- support both connecting an existing vault and creating a new normal Markdown vault under a user-selected parent folder
- add a managed `CyanBridge/` notes namespace with create + reopen + edit-in-place support
- add Markdown note tooling for headings, bullet/numbered lists, task checkboxes, bold, italic, inline code, quotes, links, wiki links, inline tags, and YAML tags/frontmatter
- keep external Obsidian `.md` files plaintext for Obsidian compatibility and explicitly separate that boundary from CyanBridge Memory Vault encryption
- add a user-selected import inbox plus 12-hour WorkManager re-indexing for future desktop/browser bridges
- inject imported personal knowledge only when the on-device Local Models provider is selected
- render common LLM Markdown and readable LaTeX-style math in shared chat bubbles
- keep user-authored imported turns separate from assistant-authored text so imported assistant output is never automatically treated as a confirmed personal fact

## Obsidian storage model
For an existing vault, CyanBridge retains scoped read/write access to the selected tree. For a vault created by CyanBridge, the user selects a parent folder, CyanBridge creates the vault directory and stores its document ID as the logical root while retaining only the parent tree permission. No all-files permission is requested.

CyanBridge only writes through the managed `CyanBridge/` folder, while the rest of the vault remains searchable/readable. Source notes stay ordinary plaintext Markdown so Obsidian can use them. Enabling CyanBridge Memory Vault encryption does **not** encrypt those external files; the UI says this explicitly.

## Privacy model
CyanBridge never logs in to ChatGPT/Claude and never uploads CyanBridge chats/vault data to them. Provider exports and Obsidian files flow inward only. Imported RAG is gated to `LOCAL_MODELS` at prompt time.

## Validation
- shared Markdown/math tests
- Android ChatGPT/Claude parser and chunking tests
- Robolectric parser tests pinned to supported SDK 34
- Obsidian Markdown metadata/tag round-trip tests
- Markdown editor selection/prefix transformation tests
- latest Android/shared unit-test stage passes; debug APK assembly is still running on the current head

Keeping the PR as draft until the full current CI run finishes.