### PR TITLE
fix(live): use constrained ephemeral auth for Pro Android

### DIFF
--- a/android/CyanBridge/app/src/main/java/com/fersaiyan/cyanbridge/MainActivity.kt
+++ b/android/CyanBridge/app/src/main/java/com/fersaiyan/cyanbridge/MainActivity.kt
@@ -7647,6 +7647,7 @@ class MainActivity : AppCompatActivity(), TextToSpeech.OnInitListener {
             var result: Result<Int>? = null
             try {
                 val project = manager.awaitProject()
+                    ?: throw IOException("Eyevue did not report its project/model; refusing to guess AP vs P2P")
                 val profile = EyevueMediaProfile.fromProject(project)
                 val sync = EyevueMediaSync(manager, transport, temporaryDirectory)
                 result = sync.sync(
@@ -7693,6 +7694,7 @@ class MainActivity : AppCompatActivity(), TextToSpeech.OnInitListener {
             } finally {
                 withContext(Dispatchers.Main) {
                     val completed = result?.getOrNull()
+                    val failureDetail = result?.exceptionOrNull()?.message
                     val cancelled = eyevueMediaCancelled
                     eyevueMediaJob = null
                     eyevueMediaTransport = null
@@ -7708,7 +7710,7 @@ class MainActivity : AppCompatActivity(), TextToSpeech.OnInitListener {
                         } else {
                             Toast.makeText(
                                 this@MainActivity,
-                                "Eyevue media sync failed. Check the transfer details and retry.",
+                                "Eyevue media sync failed: " + (failureDetail?.take(140) ?: "unknown error"),
                                 Toast.LENGTH_LONG,
                             ).show()
                         }
@@ -7721,8 +7723,8 @@ class MainActivity : AppCompatActivity(), TextToSpeech.OnInitListener {
     private fun stopEyevueMediaSync() {
         if (eyevueMediaJob?.isActive != true) return
         eyevueMediaCancelled = true
-        eyevueMediaTransport?.disconnect()
         getOrCreateEyevueManager().finishTransfer()
+        eyevueMediaTransport?.disconnect()
         eyevueMediaJob?.cancel()
         setTransferUiVisible(false)
         releaseExclusiveGlassesSession(mediaSessionLease)

--- a/android/CyanBridge/app/src/main/java/com/fersaiyan/cyanbridge/ai/live/GeminiLiveActivity.kt
+++ b/android/CyanBridge/app/src/main/java/com/fersaiyan/cyanbridge/ai/live/GeminiLiveActivity.kt
@@ -230,7 +230,6 @@ class GeminiLiveActivity : AppCompatActivity(), GeminiLiveClient.Listener {
     }
 
     override fun onInterrupted() {
-        visionController.onServerDetectedUserInterruption()
         runOnUiThread { status.text = "Gemini was interrupted. Listening for you." }
     }
 

--- a/android/CyanBridge/app/src/main/java/com/fersaiyan/cyanbridge/ai/live/GeminiLiveClient.kt
+++ b/android/CyanBridge/app/src/main/java/com/fersaiyan/cyanbridge/ai/live/GeminiLiveClient.kt
@@ -402,9 +402,24 @@ class GeminiLiveClient(
             }
 
             override fun onClosed(webSocket: WebSocket, code: Int, reason: String) {
-                Log.w(TAG, "Gemini Live socket closed code=$code reason=$reason active=${active.get()} setupComplete=${setupComplete.get()}")
+                val wasSetupComplete = setupComplete.get()
+                Log.w(TAG, "Gemini Live socket closed code=$code reason=$reason active=${active.get()} setupComplete=$wasSetupComplete")
                 if (socket === webSocket) socket = null
                 setupComplete.set(false)
+                if (!wasSetupComplete && active.get() && config.reservationId != "free-proxy" && config.reservationId != "direct") {
+                    active.set(false)
+                    scope.launch {
+                        releaseRelayReservation(
+                            reservationId = config.reservationId,
+                            inputAudioMs = inputAudioMs,
+                            outputAudioMs = outputAudioMs,
+                            imageCount = visualInputCount,
+                        )
+                    }
+                    tokenConfig = null
+                    setState(GeminiLiveState.ERROR, "Gemini Live connection failed ($code). Please try again.")
+                    return
+                }
                 if (active.get()) scheduleReconnect()
             }
 
@@ -431,6 +446,20 @@ class GeminiLiveClient(
                         setState(GeminiLiveState.ERROR, localizedFreeQueueMessage())
                         return
                     }
+                }
+                if (!setupComplete.get() && active.get() && config.reservationId != "free-proxy" && config.reservationId != "direct") {
+                    active.set(false)
+                    scope.launch {
+                        releaseRelayReservation(
+                            reservationId = config.reservationId,
+                            inputAudioMs = inputAudioMs,
+                            outputAudioMs = outputAudioMs,
+                            imageCount = visualInputCount,
+                        )
+                    }
+                    tokenConfig = null
+                    setState(GeminiLiveState.ERROR, "Gemini Live connection failed. Please try again.")
+                    return
                 }
                 if (active.get()) scheduleReconnect()
             }

--- a/android/CyanBridge/app/src/main/java/com/fersaiyan/cyanbridge/ai/live/GeminiLiveClient.kt
+++ b/android/CyanBridge/app/src/main/java/com/fersaiyan/cyanbridge/ai/live/GeminiLiveClient.kt
@@ -424,11 +424,12 @@ class GeminiLiveClient(
             }
 
             override fun onFailure(webSocket: WebSocket, t: Throwable, response: Response?) {
+                val wasSetupComplete = setupComplete.get()
                 if (socket === webSocket) socket = null
                 setupComplete.set(false)
                 Log.w(TAG, "Gemini Live socket failed code=${response?.code} msg=${response?.message} err=${t.message}", t)
-                // Free queue: server returns 429 live_free_queued with localized message
-                if (response?.code == 429) {
+                // Free queue: only the CyanBridge free proxy returns localized live_free_queued.
+                if (response?.code == 429 && config.reservationId == "free-proxy") {
                     val raw = try { response.body?.string().orEmpty() } catch (_: Exception) { "" }
                     val isQueued = raw.contains("live_free_queued") || raw.contains("live_rate_limited") || t.message?.contains("429") == true
                     if (isQueued || raw.contains("live_free_queued")) {
@@ -447,7 +448,7 @@ class GeminiLiveClient(
                         return
                     }
                 }
-                if (!setupComplete.get() && active.get() && config.reservationId != "free-proxy" && config.reservationId != "direct") {
+                if (!wasSetupComplete && active.get() && config.reservationId != "free-proxy" && config.reservationId != "direct") {
                     active.set(false)
                     scope.launch {
                         releaseRelayReservation(

--- a/android/CyanBridge/app/src/main/java/com/fersaiyan/cyanbridge/ai/live/GeminiLiveClient.kt
+++ b/android/CyanBridge/app/src/main/java/com/fersaiyan/cyanbridge/ai/live/GeminiLiveClient.kt
@@ -90,11 +90,13 @@ class GeminiLiveClient(
     private var visualAudioHoldStarted = false
     private var heldVisualSilenceChunks = 0
     private val speechDetector = GeminiLiveSpeechActivityDetector { speaking ->
+        // Always retain the local energy state. During Gemini playback we suppress the
+        // vision callback to avoid speaker echo triggering a picture, but the state is
+        // still used to confirm that a server-side interruption was backed by local speech.
+        speechActive.set(speaking)
         if (modelSpeaking.get()) {
-            speechActive.set(false)
-            Log.d(TAG, "Ignoring local speech energy during Gemini playback active=$speaking")
+            Log.d(TAG, "Local speech energy during Gemini playback active=$speaking (callback suppressed)")
         } else {
-            speechActive.set(speaking)
             Log.d(TAG, "Local speech energy active=$speaking")
             listener.onUserSpeechActivity(speaking)
         }
@@ -597,11 +599,16 @@ class GeminiLiveClient(
                 ?.let { listener.onTranscription(false, it) }
 
             if (serverContent.optBoolean("interrupted", false)) {
+                // A server interruption alone is not enough to refresh vision: it can be
+                // caused by noise/echo. Require simultaneous local energy evidence so barge-in
+                // speech still gets a fresh image without reintroducing spontaneous captures.
+                val locallyConfirmedSpeech = speechActive.get()
                 playback?.let { track ->
                     runCatching { track.pause() }
                     runCatching { track.flush() }
                 }
                 finishModelPlayback()
+                if (locallyConfirmedSpeech) listener.onUserSpeechActivity(true)
                 listener.onInterrupted()
                 // Interrupted still ends a turn — bill the partial turn via usageMetadata if present,
                 // otherwise via audio ms delta.

--- a/android/CyanBridge/app/src/main/java/com/fersaiyan/cyanbridge/ai/live/GeminiLiveForegroundService.kt
+++ b/android/CyanBridge/app/src/main/java/com/fersaiyan/cyanbridge/ai/live/GeminiLiveForegroundService.kt
@@ -303,7 +303,6 @@ class GeminiLiveForegroundService : Service(), GeminiLiveClient.Listener {
     }
 
     override fun onInterrupted() {
-        visionController?.onServerDetectedUserInterruption()
         currentDetail = "Gemini was interrupted. Listening for you."
         updateNotification()
     }

--- a/android/CyanBridge/app/src/main/java/com/fersaiyan/cyanbridge/ai/live/GeminiLiveSpeechActivityDetector.kt
+++ b/android/CyanBridge/app/src/main/java/com/fersaiyan/cyanbridge/ai/live/GeminiLiveSpeechActivityDetector.kt
@@ -7,9 +7,11 @@ import kotlin.math.abs
  * Gemini remains responsible for transcription and server-side VAD/turn taking.
  */
 class GeminiLiveSpeechActivityDetector(
-    // VOICE_COMMUNICATION processing can substantially attenuate Bluetooth microphone PCM.
-    // This detector only schedules visual refreshes; Gemini's audio path is never gated by it.
-    private val startThreshold: Int = 100,
+    // Keep the original conservative threshold used by the vision scheduler. A value of 100
+    // caused processed Bluetooth/VOICE_COMMUNICATION noise to latch the detector active,
+    // producing silent captures and preventing the next real utterance from creating a new edge.
+    // Gemini audio itself is never gated by this detector.
+    private val startThreshold: Int = 900,
     private val activeChunksToStart: Int = 2,
     // 15 x 40 ms chunks identifies a tail longer than Gemini's 500 ms server-VAD window.
     private val silentChunksToStop: Int = 15,

--- a/android/CyanBridge/app/src/main/java/com/fersaiyan/cyanbridge/ai/live/GeminiLiveTokenProvider.kt
+++ b/android/CyanBridge/app/src/main/java/com/fersaiyan/cyanbridge/ai/live/GeminiLiveTokenProvider.kt
@@ -98,7 +98,7 @@ class DefaultGeminiLiveTokenProvider(
                 throw IllegalStateException(error)
             }
             val expiresAt = Instant.parse(json.getString("expire_time")).toEpochMilli()
-            // Production Pro uses Google\'s client-to-server ephemeral-token flow.
+            // Production Pro uses Google's client-to-server ephemeral-token flow.
             // The server returns a BidiGenerateContentConstrained URL containing only
             // the short-lived access_token. No long-lived Google API key is sent to Android.
             return LiveTokenConfig(

--- a/android/CyanBridge/app/src/main/java/com/fersaiyan/cyanbridge/ai/live/GeminiLiveTokenProvider.kt
+++ b/android/CyanBridge/app/src/main/java/com/fersaiyan/cyanbridge/ai/live/GeminiLiveTokenProvider.kt
@@ -20,9 +20,9 @@ data class LiveTokenConfig(
     val expiresAtMs: Long,
     val reservationId: String,
     val authorizationHeader: String? = null,
-    /** Optional API key for direct Live websocket auth (free-tier requires x-goog-api-key alongside Token). */
+    /** Optional API key reserved for explicit local/debug providers. Production Pro never receives one. */
     val apiKey: String? = null,
-    /** Exact bidiGenerateContentSetup that was used to mint the token; if present the Live setup should echo it exactly. */
+    /** Optional setup override retained for provider/test compatibility. */
     val setupJson: String? = null,
 )
 
@@ -98,26 +98,18 @@ class DefaultGeminiLiveTokenProvider(
                 throw IllegalStateException(error)
             }
             val expiresAt = Instant.parse(json.getString("expire_time")).toEpochMilli()
-            // Debug override for end-to-end testing with a direct Gemini API key.
-            // Set via: adb shell am broadcast -a com.fersaiyan.cyanbridge.SET_GEMINI_KEY --es key "AQ...."
-            // or via SharedPreferences "debug_gemini_api_key". Not used in production relay flow.
-            val debugApiKey = appContext.getSharedPreferences("debug", Context.MODE_PRIVATE)
-                .getString("debug_gemini_api_key", null)?.trim()?.takeIf { it.isNotBlank() }
-            // Pro Live via BidiGenerateContent needs x-goog-api-key alongside Token
-            // (free proxy does Token + x-goog-api-key server-side; Pro must send
-            // the same from device to avoid 1008). Server returns api_key for Pro.
-            val serverApiKey = json.optString("api_key", "").trim().takeIf { it.isNotBlank() }
-                ?: json.optString("apiKey", "").trim().takeIf { it.isNotBlank() }
-            val setupJson = json.optJSONObject("setup")?.toString()?.takeIf { it.isNotBlank() && it != "null" }
+            // Production Pro uses Google\'s client-to-server ephemeral-token flow.
+            // The server returns a BidiGenerateContentConstrained URL containing only
+            // the short-lived access_token. No long-lived Google API key is sent to Android.
             return LiveTokenConfig(
                 token = json.getString("token"),
                 model = json.getString("model"),
                 websocketUrl = json.getString("websocket_url"),
                 expiresAtMs = expiresAt,
                 reservationId = json.getString("reservation_id"),
-                authorizationHeader = "Token ${json.getString("token")}",
-                apiKey = serverApiKey ?: debugApiKey,
-                setupJson = setupJson,
+                authorizationHeader = null,
+                apiKey = null,
+                setupJson = null,
             )
         }
     }
@@ -168,14 +160,21 @@ class DirectGeminiApiKeyLiveTokenProvider(
             val name = json.getString("name")
             val exp = json.optString("expireTime", expireTime)
             val expiresAt = java.time.Instant.parse(exp).toEpochMilli()
+            val websocketUrl = "https://generativelanguage.googleapis.com/ws/google.ai.generativelanguage.v1beta.GenerativeService.BidiGenerateContentConstrained"
+                .toHttpUrl()
+                .newBuilder()
+                .addQueryParameter("access_token", name)
+                .build()
+                .toString()
+                .replaceFirst("https://", "wss://")
             return LiveTokenConfig(
                 token = name,
                 model = "models/gemini-3.1-flash-live-preview",
-                websocketUrl = "wss://generativelanguage.googleapis.com/ws/google.ai.generativelanguage.v1beta.GenerativeService.BidiGenerateContent",
+                websocketUrl = websocketUrl,
                 expiresAtMs = expiresAt,
                 reservationId = "direct",
-                authorizationHeader = "Token $name",
-                apiKey = apiKey,
+                authorizationHeader = null,
+                apiKey = null,
             )
         }
     }

--- a/android/CyanBridge/app/src/main/java/com/fersaiyan/cyanbridge/ai/live/GeminiLiveTokenProvider.kt
+++ b/android/CyanBridge/app/src/main/java/com/fersaiyan/cyanbridge/ai/live/GeminiLiveTokenProvider.kt
@@ -129,10 +129,13 @@ class DirectGeminiApiKeyLiveTokenProvider(
             .put("uses", 1)
             .put("expireTime", expireTime)
             .put("newSessionExpireTime", newSessionExpireTime)
+            .put(
+                "fieldMask",
+                "model,generationConfig,contextWindowCompression,systemInstruction,realtimeInputConfig,inputAudioTranscription,outputAudioTranscription",
+            )
             .put("bidiGenerateContentSetup", JSONObject()
                 .put("model", "models/gemini-3.1-flash-live-preview")
                 .put("generationConfig", JSONObject().put("responseModalities", org.json.JSONArray().put("AUDIO")))
-                .put("sessionResumption", JSONObject())
                 .put("systemInstruction", JSONObject().put("parts", org.json.JSONArray().put(JSONObject().put("text", "You are Gemini Live in CyanBridge smart glasses. Reply in $language."))))
                 .put("realtimeInputConfig", JSONObject()
                     .put("automaticActivityDetection", JSONObject()

--- a/android/CyanBridge/app/src/main/java/com/fersaiyan/cyanbridge/ai/live/GeminiLiveVisionController.kt
+++ b/android/CyanBridge/app/src/main/java/com/fersaiyan/cyanbridge/ai/live/GeminiLiveVisionController.kt
@@ -105,9 +105,6 @@ class GeminiLiveVisionController(
     }
 
     fun onSpeechActivity(speaking: Boolean) {
-        if (speaking && active && capabilities.mode == GeminiLiveVisionCapabilities.Mode.OPPORTUNISTIC_STILL) {
-            maybeCaptureAutomaticStill()
-        }
         scope.launch {
             if (!active) return@launch
             val changedToSpeaking = speaking && !userSpeaking
@@ -130,18 +127,9 @@ class GeminiLiveVisionController(
                         maybeSendLatestMetaFrame()
                     }
                 }
-                GeminiLiveVisionCapabilities.Mode.OPPORTUNISTIC_STILL -> Unit
+                GeminiLiveVisionCapabilities.Mode.OPPORTUNISTIC_STILL -> maybeCaptureAutomaticStill()
                 else -> Unit
             }
-        }
-    }
-
-    fun onServerDetectedUserInterruption() {
-        if (!active) return
-        when (capabilities.mode) {
-            GeminiLiveVisionCapabilities.Mode.OPPORTUNISTIC_STILL -> maybeCaptureAutomaticStill()
-            GeminiLiveVisionCapabilities.Mode.LIVE_FRAMES -> onSpeechActivity(true)
-            else -> Unit
         }
     }
 

--- a/android/CyanBridge/app/src/main/java/com/fersaiyan/cyanbridge/ai/live/GeminiLiveVisionPreferences.kt
+++ b/android/CyanBridge/app/src/main/java/com/fersaiyan/cyanbridge/ai/live/GeminiLiveVisionPreferences.kt
@@ -2,11 +2,11 @@ package com.fersaiyan.cyanbridge.ai.live
 
 import android.content.Context
 
-/** Gemini Live-only visual refresh cadence. Zero keeps the initial image only. */
+/** Gemini Live-only visual refresh mode. Zero keeps the initial image only. */
 object GeminiLiveVisionPreferences {
-    // Simplified to two modes: only the first image, or a fresh image on every
-    // significant speech turn (energy model). The 2 s guard avoids HeyCyan shutter
-    // spam while BLE transfer (~2-4 s) is still in progress.
+    // The UI still persists 2 for backward compatibility with the existing dashboard state,
+    // but it is now a mode sentinel: 0 = only first image, 2 = every significant speech turn.
+    // There is no time-based cooldown in the every-turn mode.
     val delayOptionsSeconds = listOf(0, 2)
     private val legacyDelaySeconds = listOf(5, 10, 15)
 
@@ -33,7 +33,7 @@ object GeminiLiveVisionPreferences {
     }
 
     fun automaticRefreshIntervalMs(context: Context): Long? =
-        imageDelaySeconds(context).takeIf { it > 0 }?.times(1_000L)
+        if (imageDelaySeconds(context) > 0) 0L else null
 
     private const val PREFS_NAME = "gemini_live"
     private const val KEY_IMAGE_DELAY_SECONDS = "live_image_delay"

--- a/android/CyanBridge/app/src/main/java/com/fersaiyan/cyanbridge/devices/eyevue/EyevueMediaSync.kt
+++ b/android/CyanBridge/app/src/main/java/com/fersaiyan/cyanbridge/devices/eyevue/EyevueMediaSync.kt
@@ -107,8 +107,12 @@ class EyevueMediaSync(
         onState(state)
         temporaryDirectory.mkdirs()
         try {
-            val ssid = manager.awaitWifiSsid(profile.mode == EyevueWifiMode.P2P)
-                ?: throw IOException("Eyevue did not report a Wi-Fi SSID")
+            // The reverse-engineered vendor flow activates the glasses Wi-Fi with CMD_APP_LIVE
+            // (0x67, AP=0x30 / P2P=0x31) and then receives the SSID in command 0x25.
+            // CMD_GET_WIFI_INFO (0x39) only queries information and did not reliably bring the
+            // transfer network up on hardware.
+            val ssid = manager.startLiveAndAwaitSsid(ap = profile.mode == EyevueWifiMode.AP)
+                ?: throw IOException("Eyevue did not report a Wi-Fi SSID after starting Wi-Fi mode")
             state = state.copy(detail = "Connecting to ${profile.mode.name} Wi-Fi")
             onState(state)
             transport.connect(
@@ -155,10 +159,13 @@ class EyevueMediaSync(
             Log.e(TAG, "Eyevue media sync failed", error)
             return Result.failure(error)
         } finally {
-            // This tells the glasses to leave transfer/live mode before Wi-Fi teardown.
-            manager.finishTransfer()
-            transport.disconnect()
-            temporaryDirectory.deleteRecursively()
+            // Match the vendor cleanup order: tell the glasses to leave transfer/live mode
+            // before tearing down the Android Wi-Fi route.
+            kotlinx.coroutines.withContext(kotlinx.coroutines.NonCancellable) {
+                manager.stopLiveBlocking()
+                transport.disconnect()
+                temporaryDirectory.deleteRecursively()
+            }
         }
     }
 

--- a/android/CyanBridge/app/src/main/java/com/fersaiyan/cyanbridge/devices/eyevue/EyevueMediaSync.kt
+++ b/android/CyanBridge/app/src/main/java/com/fersaiyan/cyanbridge/devices/eyevue/EyevueMediaSync.kt
@@ -103,14 +103,14 @@ class EyevueMediaSync(
         onProgress: suspend (EyevueMediaItem, Long, Long) -> Unit = { _, _, _ -> },
         onFile: suspend (EyevueMediaItem, File) -> Boolean,
     ): Result<Int> {
-        var state = EyevueMediaSyncState(isActive = true, detail = "Requesting Eyevue Wi-Fi information")
+        var state = EyevueMediaSyncState(isActive = true, detail = "Starting Eyevue Wi-Fi mode")
         onState(state)
         temporaryDirectory.mkdirs()
         try {
             // The reverse-engineered vendor flow activates the glasses Wi-Fi with CMD_APP_LIVE
             // (0x67, AP=0x30 / P2P=0x31) and then receives the SSID in command 0x25.
-            // CMD_GET_WIFI_INFO (0x39) only queries information and did not reliably bring the
-            // transfer network up on hardware.
+            // The vendor notes do not document CMD_GET_WIFI_INFO (0x39) as the network
+            // activation step, so media sync must not rely on that query alone.
             val ssid = manager.startLiveAndAwaitSsid(ap = profile.mode == EyevueWifiMode.AP)
                 ?: throw IOException("Eyevue did not report a Wi-Fi SSID after starting Wi-Fi mode")
             state = state.copy(detail = "Connecting to ${profile.mode.name} Wi-Fi")

--- a/android/CyanBridge/app/src/main/java/com/fersaiyan/cyanbridge/devices/eyevue/EyevueWifiTransport.kt
+++ b/android/CyanBridge/app/src/main/java/com/fersaiyan/cyanbridge/devices/eyevue/EyevueWifiTransport.kt
@@ -266,6 +266,11 @@ class EyevueWifiTransport(
     private fun requestP2pPeers() {
         val channel = p2pChannel ?: return
         p2pManager.requestPeers(channel) { peers ->
+            Log.i(
+                TAG,
+                "Eyevue P2P peers target=${p2pTargetSsid.orEmpty()} peers=" +
+                    peers.deviceList.joinToString { "${it.deviceName.orEmpty()}@${it.deviceAddress}" },
+            )
             val target = findTargetPeer(peers)
             if (target == null || p2pConnecting) return@requestPeers
             p2pConnecting = true
@@ -289,8 +294,20 @@ class EyevueWifiTransport(
     private fun findTargetPeer(peers: WifiP2pDeviceList): WifiP2pDevice? {
         val target = p2pTargetSsid?.trim().orEmpty()
         if (target.isBlank()) return null
-        return peers.deviceList.firstOrNull { peer ->
-            peer.deviceName?.contains(target, ignoreCase = true) == true
+        peers.deviceList.firstOrNull { peer ->
+            peer.deviceName?.contains(target, ignoreCase = true) == true ||
+                target.contains(peer.deviceName.orEmpty(), ignoreCase = true)
+        }?.let { return it }
+
+        // The BLE-reported SSID and WifiP2pDevice.deviceName are separate vendor fields and
+        // are not guaranteed to match. Falling back is safe only when discovery exposes one
+        // candidate; never connect to an arbitrary peer when multiple devices are present.
+        return peers.deviceList.singleOrNull()?.also { peer ->
+            Log.w(
+                TAG,
+                "Eyevue P2P SSID '$target' did not match deviceName '${peer.deviceName}'; " +
+                    "using the only discovered peer ${peer.deviceAddress}",
+            )
         }
     }
 

--- a/android/CyanBridge/app/src/test/java/com/fersaiyan/cyanbridge/ai/live/GeminiLiveSpeechActivityDetectorTest.kt
+++ b/android/CyanBridge/app/src/test/java/com/fersaiyan/cyanbridge/ai/live/GeminiLiveSpeechActivityDetectorTest.kt
@@ -44,6 +44,20 @@ class GeminiLiveSpeechActivityDetectorTest {
         assertEquals(emptyList<Boolean>(), changes)
     }
 
+
+    @Test
+    fun `default detector ignores moderate background noise and reacts to significant speech`() {
+        val changes = mutableListOf<Boolean>()
+        val detector = GeminiLiveSpeechActivityDetector(onChanged = changes::add)
+
+        repeat(10) { detector.offerPcm16Le(chunk(250)) }
+        assertEquals(emptyList<Boolean>(), changes)
+
+        detector.offerPcm16Le(chunk(2_000))
+        detector.offerPcm16Le(chunk(2_000))
+        assertEquals(listOf(true), changes)
+    }
+
     private fun chunk(sample: Int, samples: Int = 640): ByteArray {
         val value = sample.toShort().toInt()
         return ByteArray(samples * 2).also { bytes ->

--- a/android/CyanBridge/app/src/test/java/com/fersaiyan/cyanbridge/ai/live/GeminiLiveVisionPreferencesTest.kt
+++ b/android/CyanBridge/app/src/test/java/com/fersaiyan/cyanbridge/ai/live/GeminiLiveVisionPreferencesTest.kt
@@ -38,7 +38,7 @@ class GeminiLiveVisionPreferencesTest {
     fun `legacy cadence migrates to every turn`() {
         assertEquals(2, GeminiLiveVisionPreferences.setImageDelaySeconds(context, 10))
         assertEquals(2, GeminiLiveVisionPreferences.imageDelaySeconds(context))
-        assertEquals(2_000L, GeminiLiveVisionPreferences.automaticRefreshIntervalMs(context))
+        assertEquals(0L, GeminiLiveVisionPreferences.automaticRefreshIntervalMs(context))
         assertEquals(2, GeminiLiveVisionPreferences.setImageDelaySeconds(context, 5))
         assertEquals(2, GeminiLiveVisionPreferences.imageDelaySeconds(context))
     }

--- a/android/CyanBridge/app/src/test/java/com/fersaiyan/cyanbridge/ai/live/GeminiLiveVisionPreferencesTest.kt
+++ b/android/CyanBridge/app/src/test/java/com/fersaiyan/cyanbridge/ai/live/GeminiLiveVisionPreferencesTest.kt
@@ -31,7 +31,7 @@ class GeminiLiveVisionPreferencesTest {
     @Test
     fun `supported cadence is persisted in milliseconds`() {
         assertEquals(2, GeminiLiveVisionPreferences.setImageDelaySeconds(context, 2))
-        assertEquals(2_000L, GeminiLiveVisionPreferences.automaticRefreshIntervalMs(context))
+        assertEquals(0L, GeminiLiveVisionPreferences.automaticRefreshIntervalMs(context))
     }
 
     @Test

--- a/android/CyanBridge/app/src/test/java/com/fersaiyan/cyanbridge/devices/eyevue/EyevueReleaseSafetyTest.kt
+++ b/android/CyanBridge/app/src/test/java/com/fersaiyan/cyanbridge/devices/eyevue/EyevueReleaseSafetyTest.kt
@@ -14,6 +14,16 @@ class EyevueReleaseSafetyTest {
     private val liveSource = File(
         "src/main/java/com/fersaiyan/cyanbridge/devices/eyevue/EyevueLivePreviewManager.kt",
     ).readText()
+    private val mediaSource = File(
+        "src/main/java/com/fersaiyan/cyanbridge/devices/eyevue/EyevueMediaSync.kt",
+    ).readText()
+
+    @Test
+    fun eyevueMediaSyncUsesVerifiedWifiActivationCommand() {
+        assertTrue(mediaSource.contains("manager.startLiveAndAwaitSsid"))
+        assertFalse(mediaSource.contains("manager.awaitWifiSsid("))
+        assertTrue(mediaSource.contains("manager.stopLiveBlocking()"))
+    }
 
     @Test
     fun eyevueLivePreviewIsReleaseEnabledWithoutExtraWifiCommands() {


### PR DESCRIPTION
## Summary
- target the existing `test/audio-emulator-harness` integration branch
- keep the free-user Vercel WebSocket flow unchanged
- Pro Android no longer accepts or sends a long-lived Google API key
- Pro uses the server-provided `BidiGenerateContentConstrained?access_token=...` URL
- direct debug provider now exercises the same constrained ephemeral-token auth path
- release failed initial Pro handshakes so stale concurrent-session reservations do not linger

## Live vision regression fix
- restore the original significant-speech detector threshold (`900`; the later `100` threshold was firing on ambient/processed mic noise)
- remove the runtime 2-second cooldown from “Every speech turn”; it is now edge-driven, not timer-driven
- automatic still/frame refresh happens only on a new confirmed local speech onset
- a bare Gemini `interrupted` event no longer triggers a picture by itself
- barge-in during Gemini playback can still trigger vision, but only when the server interruption is backed by local energy evidence
- add regression tests for background-noise false positives and zero-cooldown every-speech mode

Paired website PR #10 mints the token with the billing-enabled Vercel/GCP credential.

## Preserved latency optimization
- preserve the existing parallel visual/audio handoff from `94e354a4`: while a fresh still transfers from the glasses, the user's speech continues toward Gemini; only the turn-ending silence tail is held, the JPEG is sent first, and then the held silence is released so server VAD finalizes the turn with the fresh image attached to already-processed speech.


## Eyevue Wi-Fi sync
- trace the dashboard StartSync path to `startEyevueMediaSync()`; the button is wired correctly
- use the reverse-engineered vendor Wi-Fi activation sequence for media sync: `0x67/0x30` for AP or `0x67/0x31` for P2P, then wait for the `0x25` SSID response
- keep the corrected Eyevue datagram length (`payload + 2`)
- refuse to guess P2P when the Eyevue project/model response is missing
- tolerate BLE SSID vs Wi-Fi Direct device-name mismatch only when exactly one P2P peer is visible
- send `0x44 0x30 0x01` cleanup before Wi-Fi teardown and surface the concrete sync error
- add a regression guard preventing media sync from falling back to the unverified `0x39` query-only bootstrap

The manifest endpoints (`cmd=3015` and T-series `/app/getfilelist`) remain unchanged because the checked-in reverse-engineering notes do not establish a better replacement; hardware retest should now distinguish Wi-Fi bootstrap failures from HTTP manifest failures.
